### PR TITLE
postfix: disable `virtual` and `local` MDAs

### DIFF
--- a/deploy-chatmail/src/deploy_chatmail/postfix/master.cf.j2
+++ b/deploy-chatmail/src/deploy_chatmail/postfix/master.cf.j2
@@ -70,8 +70,6 @@ showq     unix  n       -       y       -       -       showq
 error     unix  -       -       y       -       -       error
 retry     unix  -       -       y       -       -       error
 discard   unix  -       -       y       -       -       discard
-local     unix  -       n       n       -       -       local
-virtual   unix  -       n       n       -       -       virtual
 lmtp      unix  -       -       y       -       -       lmtp
 anvil     unix  -       -       y       -       1       anvil
 scache    unix  -       -       y       -       1       scache


### PR DESCRIPTION
We do not need them, all mails are delivered to Dovecot over LMTP.