### PR TITLE
Require that passwords are at least 10 characters long

### DIFF
--- a/chatmaild/src/chatmaild/dictproxy.py
+++ b/chatmaild/src/chatmaild/dictproxy.py
@@ -21,15 +21,27 @@ def encrypt_password(password: str):
     return "{SHA512-CRYPT}" + passhash
 
 
-def create_user(db, user, password):
+def check_password(password) -> bool:
+    """Check password policy"""
+    if len(password) < 10:
+        return False
+    return True
+
+
+def create_user(db, user, encrypted_password):
     if os.path.exists(NOCREATE_FILE):
         logging.warning(
             f"Didn't create account: {NOCREATE_FILE} exists. Delete the file to enable account creation."
         )
         return
     with db.write_transaction() as conn:
-        conn.create_user(user, password)
-    return dict(home=f"/home/vmail/{user}", uid="vmail", gid="vmail", password=password)
+        conn.create_user(user, encrypted_password)
+    return dict(
+        home=f"/home/vmail/{user}",
+        uid="vmail",
+        gid="vmail",
+        password=encrypted_password,
+    )
 
 
 def get_user_data(db, user):
@@ -48,6 +60,9 @@ def lookup_userdb(db, user):
 def lookup_passdb(db, user, password):
     userdata = get_user_data(db, user)
     if not userdata:
+        if not check_password(password):
+            logging.warning("Attempt to create an account with a weak password.")
+            return
         return create_user(db, user, encrypt_password(password))
     userdata["password"] = userdata["password"].strip()
     return userdata

--- a/tests/chatmaild/test_dictproxy.py
+++ b/tests/chatmaild/test_dictproxy.py
@@ -18,7 +18,7 @@ def test_basic(db):
     chatmaild.dictproxy.NOCREATE_FILE = "/tmp/nocreate"
     if os.path.exists(chatmaild.dictproxy.NOCREATE_FILE):
         os.remove(chatmaild.dictproxy.NOCREATE_FILE)
-    lookup_passdb(db, "link2xt@c1.testrun.org", "asdf")
+    lookup_passdb(db, "link2xt@c1.testrun.org", "Pieg9aeToe3eghuthe5u")
     data = get_user_data(db, "link2xt@c1.testrun.org")
     assert data
 
@@ -37,7 +37,7 @@ def test_nocreate_file(db):
     with open(chatmaild.dictproxy.NOCREATE_FILE, "w+") as f:
         f.write("")
     assert os.path.exists(chatmaild.dictproxy.NOCREATE_FILE)
-    lookup_passdb(db, "newuser1@something.org", "kajdlqweqwe")
+    lookup_passdb(db, "newuser1@something.org", "zequ0Aimuchoodaechik")
     assert not get_user_data(db, "newuser1@something.org")
     os.remove(chatmaild.dictproxy.NOCREATE_FILE)
 

--- a/tests/online/test_0_login.py
+++ b/tests/online/test_0_login.py
@@ -23,6 +23,11 @@ def test_login_basic_functioning(imap_or_smtp, gencreds, lp):
     with pytest.raises(imap_or_smtp.AuthError):
         imap_or_smtp.login(user, password + "wrong")
 
+    lp.sec(f"creating users with a short password is not allowed")
+    user, _password = gencreds()
+    with pytest.raises(imap_or_smtp.AuthError):
+        imap_or_smtp.login(user, "admin")
+
 
 def test_login_same_password(imap_or_smtp, gencreds):
     """Test two different users logging in with the same password


### PR DESCRIPTION
There is no config file for password policy, but at least a central place where it can be implemented.

I renamed the variable to `encrypted_password` where it is actually already hashed to avoid accidentally checking the length of the hash instead of checking the length of the password.

I need this restriction so very short passwords are invalid and I can continue with https://github.com/deltachat/deltachat-core-rust/pull/4837