### PR TITLE
dovecot: increase number of simultaneous connections handled by imap-login

### DIFF
--- a/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
+++ b/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
@@ -118,6 +118,24 @@ service auth-worker {
   user = vmail
 }
 
+service imap-login {
+    # High-security mode.
+    # Each process serves a single connection and exits afterwards.
+    # This is the default, but we set it explicitly to be sure.
+    # See <https://doc.dovecot.org/admin_manual/login_processes/#high-security-mode> for details.
+    service_count = 1
+
+    # Inrease the number of simultaneous connections.
+    #
+    # As of Dovecot 2.3.19.1 the default is 100 processes.
+    # Combined with `service_count = 1` it means only 100 connections
+    # can be handled simultaneously.
+    process_limit = 10000
+
+    # Avoid startup latency for new connections.
+    process_min_avail = 10
+}
+
 ssl = required
 ssl_cert = </var/lib/acme/live/{{ config.hostname }}/fullchain
 ssl_key = </var/lib/acme/live/{{ config.hostname }}/privkey


### PR DESCRIPTION
Otherwise deltachat core CI running fails with "Connection queue full"
error on IMAP connections.

Fixes #59
