### PR TITLE
Add NOTIFY capability

### DIFF
--- a/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
+++ b/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
@@ -19,7 +19,7 @@ mail_plugins = quota
 # these are the capabilities Delta Chat cares about actually 
 # so let's keep the network overhead per login small
 # https://github.com/deltachat/deltachat-core-rust/blob/master/src/imap/capabilities.rs
-imap_capability = IMAP4rev1 IDLE MOVE QUOTA CONDSTORE
+imap_capability = IMAP4rev1 IDLE MOVE QUOTA CONDSTORE NOTIFY
 
 
 # Authentication for system users.


### PR DESCRIPTION
Delta Chat does not use it now,
but should: <https://github.com/deltachat/deltachat-core-rust/issues/4983>
Having no capability will confuse whoever develops it.