### PR TITLE
opendkim: correctly specify SigningTable in opendkim.conf

### DIFF
--- a/deploy-chatmail/src/deploy_chatmail/opendkim/opendkim.conf
+++ b/deploy-chatmail/src/deploy_chatmail/opendkim/opendkim.conf
@@ -20,7 +20,7 @@ Domain			{{ config.domain_name }}
 Selector		{{ config.opendkim_selector }}
 KeyFile		  /etc/dkimkeys/{{ config.opendkim_selector }}.private
 KeyTable          /etc/dkimkeys/KeyTable
-SigningTable      /etc/dkimkeys/SigningTable
+SigningTable      refile:/etc/dkimkeys/SigningTable
 
 # In Debian, opendkim runs as user "opendkim". A umask of 007 is required when
 # using a local socket with MTAs that access the socket as a non-privileged


### PR DESCRIPTION
fix #84 

Now it works again:

![image](https://github.com/deltachat/chatmail/assets/57442838/ab074d15-c351-403f-aa62-fb2febec9f37)

deployed on c1 and c2 already.