### PR TITLE
filtermail: always allow privacy@testrun.org

### DIFF
--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -34,7 +34,7 @@ def check_encrypted(message):
     return True
 
 
-def check_passthrough(recipient):
+def is_passthrough_recipient(recipient):
     """Check whether a recipient is configured as passthrough."""
     passthroughlist = ["privacy@testrun.org"]
     if recipient in passthroughlist:
@@ -126,8 +126,8 @@ def check_DATA(envelope):
         if envelope.mail_from == recipient:
             # Always allow sending emails to self.
             continue
-        if check_passthrough(recipient):
-            # Always allow recipients marked as passthrough in chatmail.ini
+        if is_passthrough_recipient(recipient):
+            # Always allow recipients marked as passthrough
             continue
         res = recipient.split("@")
         if len(res) != 2:

--- a/tests/chatmaild/test_filtermail.py
+++ b/tests/chatmaild/test_filtermail.py
@@ -1,4 +1,4 @@
-from chatmaild.filtermail import check_encrypted, check_DATA, SendRateLimiter, check_mdn, check_passthrough
+from chatmaild.filtermail import check_encrypted, check_DATA, SendRateLimiter, check_mdn, is_passthrough_recipient
 import pytest
 
 
@@ -87,7 +87,7 @@ def test_excempt_privacy(maildata, gencreds):
     to_addr = "privacy@testrun.org"
     false_to = "privacy@tstrn.org"
     false_to2 = "prvcy@testrun.org"
-    assert check_passthrough(to_addr)
+    assert is_passthrough_recipient(to_addr)
 
     msg = maildata("plain.eml", from_addr, to_addr)
 


### PR DESCRIPTION
fix #90 

This works for now, but we could also extend this PR to:

- [ ] Make passthrough recipients configurable in a server-side config file (/etc/chatmail.ini is only local so far)
- [ ] Enable regex parameters for passthrough recipients
