### PR TITLE
postfix: enforce TLSv1.2, disallow some insecure TLS ciphers

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -24,7 +24,22 @@ smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtp_tls_policy_maps = socketmap:inet:127.0.0.1:8461:postfix
 smtpd_tls_protocols = >=TLSv1.2
-smtpd_tls_exclude_ciphers = ECDHE-RSA-RC4-SHA, RC4, aNULL, DES-CBC3-SHA, ECDHE-RSA-DES-CBC3-SHA, EDH-RSA-DES-CBC3-SHA
+
+# Disable anonymous cipher suites
+# and known insecure algorithms.
+#
+# Disabling anonymous ciphers
+# does not generally improve security
+# because clients that want to verify certificate
+# will not select them anyway,
+# but makes cipher suite list shorter and security scanners happy.
+# See <https://www.postfix.org/TLS_README.html> for discussion.
+#
+# Only ancient insecure ciphers should be disabled here
+# as MTA clients that do not support more secure cipher
+# likely do not support MTA-STS either and will
+# otherwise fall back to using plaintext connection.
+smtpd_tls_exclude_ciphers = aNULL, RC4, MD5, DES
 
 # Override client's preference order.
 # <https://www.postfix.org/postconf.5.html#tls_preempt_cipherlist>


### PR DESCRIPTION
https://www.hardenize.com/report/c3.testrun.org/1702069777#email_tls is already mostly happy, but not entirely: 

"Reconfigure server to use forward secrecy and authenticated encryption

Even though this server supports TLS 1.2, the cipher suite configuration is suboptimal. We recommend that you reconfigure the server so that the cipher suites providing forward secrecy (ECDHE or DHE in the name, in this order of preference) and authenticated encryption (GCM or CHACHA20 in the name) are at the top. The server must also be configured to select the best-available suite."

I already tried some of the options mailcow.testrun.org uses, but avoided just copy-pasting everything because I still hope we can keep it minimal, and want to understand what's going on.

fix #77 