### PR TITLE
Do not attmpt to activate venv from scripts/initenv.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ DNS domain name (FQDN), for example `chat.example.org`.
         ssh root@CHATMAIL_DOMAIN 
    ```
 
-2. Install the `cmdeploy` command in a virtualenv 
+2. Install the `cmdeploy` command in a virtualenv and activate it
 
    ```
-    source scripts/initenv.sh
+    scripts/initenv.sh
+    . venv/bin/activate
    ```
   
 3. Create chatmail configuration file `chatmail.ini`:

--- a/scripts/initenv.sh
+++ b/scripts/initenv.sh
@@ -4,6 +4,3 @@ python3 -m venv venv
 
 venv/bin/pip install -e chatmaild 
 venv/bin/pip install -e cmdeploy
-
-source venv/bin/activate
-echo activated 'venv' python virtualenv environment containing "cmdeploy" tool


### PR DESCRIPTION
If you run it as scripts/initenv.sh,
activating venv is useless as bash will exit immediately afterwards.

If you `source` it as suggested by README.md,
`set -e` will set the flag for the current shell
and your shell will exit as soon as some command returns non-zero status,
e.g. cmdeploy fails or you simply do `ls /foo/bar/baz` and `ls`
complains that `/foo/bar/baz` does not exist.
