### PR TITLE
Setup `unbound` DNS resolver

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -378,6 +378,20 @@ def deploy_chatmail(mail_domain: str, mail_server: str, dkim_selector: str) -> N
         system=True,
     )
 
+    # Run local DNS resolver `unbound`.
+    # `resolvconf` takes care of setting up /etc/resolv.conf
+    # to use 127.0.0.1 as the resolver.
+    apt.packages(
+        name="Install unbound",
+        packages="unbound",
+    )
+    systemd.service(
+        name="Start and enable unbound",
+        service="unbound.service",
+        running=True,
+        enabled=True,
+    )
+
     # Deploy acmetool to have TLS certificates.
     deploy_acmetool(nginx_hook=True, domains=[mail_server, f"mta-sts.{mail_server}"])
 


### PR DESCRIPTION
Closes #56

This works out of the box. We may want to tweak its default configuration, but this is good enough for now.