### PR TITLE
Use dig +short option to simplify DNS parsing

### DIFF
--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -37,21 +37,15 @@ class DNS:
 
     def get(self, typ: str, domain: str) -> str | None:
         """Get a DNS entry"""
-        dig_result = self.shell(f"dig {typ} {domain}")
-        line_num = 0
-        for line in dig_result.splitlines():
-            line_num += 1
-            if line.strip() == ";; ANSWER SECTION:":
-                return dig_result.splitlines()[line_num].split("\t")[-1]
+        dig_result = self.shell(f"dig -r -q {domain} -t {typ} +short")
+        line = dig_result.partition("\n")[0]
+        if line:
+            return line
 
-    def check_ptr_record(self, ip: str, mail_domain) -> str:
+    def check_ptr_record(self, ip: str, mail_domain) -> bool:
         """Check the PTR record for an IPv4 or IPv6 address."""
-        result = self.get("-x", ip)
-        if result:
-            if ip_address(ip).version == 6:
-                result = result.split()[-1]
-            if result[:-1] == mail_domain:
-                return result
+        result = self.shell(f"dig -r -x {ip} +short").rstrip()
+        return result == f"{mail_domain}."
 
 
 def show_dns(args, out):


### PR DESCRIPTION
Without this option parsing of answer was flaky
as for long records like
_submission._tcp.nine.testrun.org.
dig printed the result with a space rather
than tab as a separator and .split("\t") did not work.

This change makes the `dig` command print the answer in the form we need so there is no need for complex parsing other than taking the first line.

`-r` option is added to make sure options are not changed by .digrc in the root home directory.