### PR TITLE
doveauth: fix home directory returned from lookup_passdb

### DIFF
--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -91,7 +91,7 @@ def lookup_passdb(db, config: Config, user, cleartext_password):
                VALUES (?, ?, ?)"""
         conn.execute(q, (user, encrypted_password, int(time.time())))
         return dict(
-            home=f"/home/vmail/{user}",
+            home=f"/home/vmail/mail/{config.mail_domain}/{user}",
             uid="vmail",
             gid="vmail",
             password=encrypted_password,

--- a/chatmaild/src/chatmaild/tests/test_doveauth.py
+++ b/chatmaild/src/chatmaild/tests/test_doveauth.py
@@ -61,7 +61,10 @@ def test_handle_dovecot_request(db, example_config):
     assert res
     assert res[0] == "O" and res.endswith("\n")
     userdata = json.loads(res[1:].strip())
-    assert userdata["home"] == "/home/vmail/some42123@chat.example.org"
+    assert (
+        userdata["home"]
+        == "/home/vmail/mail/chat.example.org/some42123@chat.example.org"
+    )
     assert userdata["uid"] == userdata["gid"] == "vmail"
     assert userdata["password"].startswith("{SHA512-CRYPT}")
 


### PR DESCRIPTION
It is currently unused, but better have it correct in case of enabling debugging options such as rawlogs.