### PR TITLE
rspamd: give the reason to MTA when incoming mail is rejected

### DIFF
--- a/cmdeploy/src/cmdeploy/rspamd/force_actions.conf
+++ b/cmdeploy/src/cmdeploy/rspamd/force_actions.conf
@@ -1,19 +1,32 @@
 rules {
-    # Reject on missing or invalid DKIM signature.
-    #
-    # We require DKIM signature on incoming mails regardless of DMARC policy.
-    #
-    # - R_DKIM_REJECT: DKIM reject inserted by `dkim` module.
-    # - R_DKIM_PERMFAIL: permanent failure inserted by `dkim` module e.g. no DKIM DNS record found.
-    # - No DKIM signing (R_DKIM_NA symbol inserted by `dkim` module)
-    REJECT_DKIM {
+    ## Reject on missing or invalid DKIM signatures.
+    ##
+    ## We require DKIM signature on incoming mails regardless of DMARC policy.
+
+    # R_DKIM_REJECT: DKIM reject inserted by `dkim` module.
+    REJECT_INVALID_DKIM {
         action = "reject";
-        expression = "R_DKIM_REJECT | R_DKIM_PERMFAIL | R_DKIM_NA";
-        message = "Rejected due to missing or invalid DKIM signature";
+        expression = "R_DKIM_REJECT";
+        message = "Rejected due to invalid DKIM signature";
     }
 
-    # Reject on SPF failure.
-    #
+    # R_DKIM_PERMFAIL: permanent failure inserted by `dkim` module e.g. no DKIM DNS record found.
+    REJECT_PERMFAIL_DKIM {
+        action = "reject";
+        expression = "R_DKIM_PERMFAIL";
+        message = "Rejected due to missing DKIM DNS entry";
+    }
+
+    # No DKIM signature (R_DKIM_NA symbol inserted by `dkim` module).
+    REJECT_MISSING_DKIM {
+        action = "reject";
+        expression = "R_DKIM_NA";
+        message = "Rejected due to missing DKIM signature";
+    }
+
+
+    ## Reject on SPF failure.
+
     # - SPF failure (R_SPF_FAIL)
     # - SPF permanent failure, e.g. failed to resolve DNS record referenced from SPF (R_SPF_PERMFAIL)
     REJECT_SPF {
@@ -28,6 +41,7 @@ rules {
         expression = "DMARC_POLICY_REJECT";
         message = "Rejected due to DMARC policy";
     }
+
 
     # Do not reject if:
     # - R_DKIM_TEMPFAIL, it is a DNS resolution failure


### PR DESCRIPTION
This is not secret but makes it easier for mail server admins to debug why chatmail does not accept their emails. If the server generates bounce messages, users will also see this and can redirect to their server support.
It also shows up in /var/log/rspamd/rspamd.log on chatmail server.