### PR TITLE
Nicer /new URL for new accounts and redirect GET requests

### DIFF
--- a/cmdeploy/src/cmdeploy/genqr.py
+++ b/cmdeploy/src/cmdeploy/genqr.py
@@ -6,7 +6,7 @@ import io
 
 
 def gen_qr_png_data(maildomain):
-    url = f"DCACCOUNT:https://{maildomain}/cgi-bin/newemail.py"
+    url = f"DCACCOUNT:https://{maildomain}/new"
     image = gen_qr(maildomain, url)
     temp = io.BytesIO()
     image.save(temp, format="png")

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -45,8 +45,22 @@ http {
 			default_type text/plain;
 		}
 
-		# add cgi-bin support
-		include /usr/share/doc/fcgiwrap/examples/nginx.conf;
+		location /new {
+			if ($request_method = GET) {
+				# Redirect to Delta Chat,
+				# which will in turn do a POST request.
+				return 301 dcaccount:https://{{ config.domain_name }}/new;
+			}
+
+			fastcgi_pass unix:/run/fcgiwrap.socket;
+			include /etc/nginx/fastcgi_params;
+			fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/newemail.py;
+		}
+
+		# Old URL for compatibility with e.g. printed QR codes.
+		location /cgi-bin/newemail.py {
+			return 301 /new;
+		}
 	}
 
 	# Redirect www. to non-www

--- a/www/src/index.md
+++ b/www/src/index.md
@@ -7,7 +7,7 @@ Welcome to instant, interoperable and [privacy-preserving](privacy.html) messagi
 
 👉 **Tap** or scan this QR code to get a random `@{{config.mail_domain}}` e-mail address
 
-<a href="DCACCOUNT:https://{{ config.mail_domain }}/cgi-bin/newemail.py">
+<a href="DCACCOUNT:https://{{ config.mail_domain }}/new">
     <img width=300 style="float: none;" src="qr-chatmail-invite-{{config.mail_domain}}.png" /></a>
 
 🐣 **Choose** your Avatar and Name


### PR DESCRIPTION
If user types in https://nine.testrun.org/new manually in the browser, at least Firefox and Brave suggest to open the app after following the redirect.

Fixes #162

Here is an example of opening in Mull (Firefox) private mode:
![screen1](https://github.com/deltachat/chatmail/assets/18373967/dd3175aa-9896-4662-b06f-c1099d6472e3)
