### PR TITLE
Add ADSP DNS record

### DIFF
--- a/cmdeploy/src/cmdeploy/chatmail.zone.f
+++ b/cmdeploy/src/cmdeploy/chatmail.zone.f
@@ -13,3 +13,4 @@ mta-sts.{chatmail_domain}.           CNAME {chatmail_domain}.
 www.{chatmail_domain}.               CNAME {chatmail_domain}.
 _smtp._tls.{chatmail_domain}.        TXT "v=TLSRPTv1;rua=mailto:{email}"
 {dkim_entry}
+_adsp._domainkey.{chatmail_domain}.  TXT "dkim=discardable"


### PR DESCRIPTION
# Based on PR #186

ADSP RFC 5617 is declared historic because of no deployment:
<https://datatracker.ietf.org/doc/status-change-adsp-rfc5617-to-historic/>

However, it is declared as supported by <https://github.com/fastmail/authentication_milter>.

OpenDKIM has a release note from 2014-12-27 saying "Discontinue support for ADSP"
and does not support ADSP anymore.

Anyway, it does not hurt to publish a TXT record
indicating the strictest possible ADSP policy
that we apply to all incoming mail ourselves.
Unlike DMARC which allows either SPF or DKIM to pass,
ADSP requires that DKIM passes.

Closes #188