### PR TITLE
Do not use redirect on /cgi-bin/newemail.py

### DIFF
--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -58,8 +58,19 @@ http {
 		}
 
 		# Old URL for compatibility with e.g. printed QR codes.
+		#
+		# Copy-paste instead of redirect to /new
+		# because Delta Chat core does not follow redirects.
+		#
+		# Redirects are only for browsers.
 		location /cgi-bin/newemail.py {
-			return 301 /new;
+			if ($request_method = GET) {
+				return 301 dcaccount:https://{{ config.domain_name }}/new;
+			}
+
+			fastcgi_pass unix:/run/fcgiwrap.socket;
+			include /etc/nginx/fastcgi_params;
+			fastcgi_param SCRIPT_FILENAME /usr/lib/cgi-bin/newemail.py;
 		}
 	}
 


### PR DESCRIPTION
Delta Chat does not follow redirects,
so it breaks old QR codes printed on paper
and published on various web pages.