### PR TITLE
Enable push_notification plugin

### DIFF
--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "iniconfig",
   "deltachat-rpc-server",
   "deltachat-rpc-client",
+  "requests",
 ]
 
 [tool.setuptools]
@@ -20,6 +21,7 @@ where = ['src']
 
 [project.scripts]
 doveauth = "chatmaild.doveauth:main"
+chatmail-metadata = "chatmaild.metadata:main"
 filtermail = "chatmaild.filtermail:main"
 echobot = "chatmaild.echo:main"
 chatmail-metrics = "chatmaild.metrics:main"

--- a/chatmaild/src/chatmaild/chatmail-metadata.service.f
+++ b/chatmaild/src/chatmaild/chatmail-metadata.service.f
@@ -1,0 +1,10 @@
+[Unit]
+Description=Chatmail dict proxy for IMAP METADATA
+
+[Service]
+ExecStart={execpath} /run/dovecot/metadata.socket vmail {config_path}
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -1,0 +1,106 @@
+import pwd
+from socketserver import (
+    UnixStreamServer,
+    StreamRequestHandler,
+    ThreadingMixIn,
+)
+from .config import read_config, Config
+import sys
+import logging
+import os
+import requests
+
+
+def handle_dovecot_protocol(rfile, wfile, tokens, requests_session, config: Config):
+    # HELLO message, ignored.
+    msg = rfile.readline().strip().decode()
+
+    transactions = {}
+
+    while True:
+        msg = rfile.readline().strip().decode()
+        if not msg:
+            break
+
+        short_command = msg[0]
+        if short_command == "L":
+            wfile.write(b"N\n")
+        elif short_command == "S":
+            # See header of
+            # <https://github.com/dovecot/core/blob/5e7965632395793d9355eb906b173bf28d2a10ca/src/lib-storage/mailbox-attribute.h>
+            # for the documentation on the structure of the key.
+
+            # Request GETMETADATA "INBOX" /private/chatmail
+            # results in a query for
+            # priv/dd72550f05eadc65542a1200cac67ad7/chatmail
+            #
+            # Request GETMETADATA "" /private/chatmail
+            # results in
+            # priv/dd72550f05eadc65542a1200cac67ad7/vendor/vendor.dovecot/pvt/server/chatmail
+
+            parts = msg[1:].split("\t")
+            transaction_id = parts[0]
+            keyname = parts[1].split("/")
+            value = parts[2] if len(parts) > 2 else ""
+            if keyname[0] == "priv" and keyname[2] == "devicetoken":
+                tokens[keyname[1]] = value
+            elif keyname[0] == "priv" and keyname[2] == "messagenew":
+                guid = keyname[1]
+                token = tokens.get(guid)
+                if token:
+                    response = requests_session.post(
+                        "https://notifications.delta.chat/notify",
+                        data=token,
+                        timeout=60,
+                    )
+                    if response.status_code == 410:
+                        # 410 Gone status code
+                        # means the token is no longer valid.
+                        del tokens[guid]
+            else:
+                # Transaction failed.
+                transactions[transaction_id] = b"F\n"
+        elif short_command == "B":
+            # Begin transaction.
+            transaction_id = msg[1:].split("\t")[0]
+            transactions[transaction_id] = b"O\n"
+        elif short_command == "C":
+            # Commit transaction.
+            transaction_id = msg[1:].split("\t")[0]
+            wfile.write(transactions.pop(transaction_id, b"N\n"))
+
+        wfile.flush()
+
+
+class ThreadedUnixStreamServer(ThreadingMixIn, UnixStreamServer):
+    request_queue_size = 100
+
+
+def main():
+    socket, username, config = sys.argv[1:]
+    passwd_entry = pwd.getpwnam(username)
+    config = read_config(config)
+    tokens = {}
+    requests_session = requests.Session()
+
+    class Handler(StreamRequestHandler):
+        def handle(self):
+            try:
+                handle_dovecot_protocol(
+                    self.rfile, self.wfile, tokens, requests_session, config
+                )
+            except Exception:
+                logging.exception("Exception in the handler")
+                raise
+
+    try:
+        os.unlink(socket)
+    except FileNotFoundError:
+        pass
+
+    with ThreadedUnixStreamServer(socket, Handler) as server:
+        os.chown(socket, uid=passwd_entry.pw_uid, gid=passwd_entry.pw_gid)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass

--- a/chatmaild/src/chatmaild/tests/test_doveauth.py
+++ b/chatmaild/src/chatmaild/tests/test_doveauth.py
@@ -17,7 +17,7 @@ from chatmaild.database import DBError
 
 def test_basic(db, example_config):
     lookup_passdb(db, example_config, "asdf12345@chat.example.org", "q9mr3faue")
-    data = get_user_data(db, "asdf12345@chat.example.org")
+    data = get_user_data(db, example_config, "asdf12345@chat.example.org")
     assert data
     data2 = lookup_passdb(
         db, example_config, "asdf12345@chat.example.org", "q9mr3jewvadsfaue"
@@ -43,7 +43,7 @@ def test_nocreate_file(db, monkeypatch, tmpdir, example_config):
     lookup_passdb(
         db, example_config, "newuser12@chat.example.org", "zequ0Aimuchoodaechik"
     )
-    assert not get_user_data(db, "newuser12@chat.example.org")
+    assert not get_user_data(db, example_config, "newuser12@chat.example.org")
 
 
 def test_db_version(db):

--- a/cmdeploy/src/cmdeploy/dovecot/default.sieve
+++ b/cmdeploy/src/cmdeploy/dovecot/default.sieve
@@ -1,0 +1,5 @@
+require ["imap4flags"];
+
+if header :is ["Auto-Submitted"] ["auto-replied", "auto-generated"] {
+	addflag "$Auto";
+}

--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -21,7 +21,7 @@ mail_plugins = quota
 # these are the capabilities Delta Chat cares about actually 
 # so let's keep the network overhead per login small
 # https://github.com/deltachat/deltachat-core-rust/blob/master/src/imap/capabilities.rs
-imap_capability = IMAP4rev1 IDLE MOVE QUOTA CONDSTORE NOTIFY METADATA
+imap_capability = IMAP4rev1 IDLE MOVE QUOTA CONDSTORE NOTIFY METADATA XDELTAPUSH
 
 
 # Authentication for system users.
@@ -71,6 +71,9 @@ mail_privileged_group = vmail
 ## Mail processes
 ##
 
+# Pass all IMAP METADATA requests to the server implementing Dovecot's dict protocol.
+mail_attribute_dict = proxy:/run/dovecot/metadata.socket:metadata
+
 # Enable IMAP COMPRESS (RFC 4978).
 # <https://datatracker.ietf.org/doc/html/rfc4978.html>
 protocol imap {
@@ -79,7 +82,21 @@ protocol imap {
 }
 
 protocol lmtp {
-  mail_plugins = $mail_plugins quota
+  # quota plugin documentation:
+  # <https://doc.dovecot.org/configuration_manual/quota_plugin/>
+  #
+  # notify plugin is a dependency of push_notification plugin:
+  # <https://doc.dovecot.org/settings/plugin/notify-plugin/>
+  #
+  # push_notification plugin documentation:
+  # <https://doc.dovecot.org/configuration_manual/push_notification/>
+  #
+  # mail_lua and push_notification_lua are needed for Lua push notification handler.
+  # <https://doc.dovecot.org/configuration_manual/push_notification/#configuration>
+  #
+  # Sieve to mark messages that should not be notified as \Seen
+  # <https://doc.dovecot.org/configuration_manual/sieve/configuration/>
+  mail_plugins = $mail_plugins quota mail_lua notify push_notification push_notification_lua sieve
 }
 
 plugin {
@@ -95,7 +112,15 @@ plugin {
   # quota_over_flag_value = TRUE
 }
 
+# push_notification configuration
+plugin {
+  # <https://doc.dovecot.org/configuration_manual/push_notification/#lua-lua>
+  push_notification_driver = lua:file=/etc/dovecot/push_notification.lua
+}
 
+plugin {
+  sieve_default = file:/etc/dovecot/default.sieve
+}
 
 service lmtp {
   user=vmail

--- a/cmdeploy/src/cmdeploy/dovecot/push_notification.lua
+++ b/cmdeploy/src/cmdeploy/dovecot/push_notification.lua
@@ -1,0 +1,32 @@
+function dovecot_lua_notify_begin_txn(user)
+  return user
+end
+
+function contains(v, needle)
+  for _, keyword in ipairs(v) do
+    if keyword == needle then
+      return true
+    end
+  end
+  return false
+end
+
+function dovecot_lua_notify_event_message_new(user, event)
+  local mbox = user:mailbox(event.mailbox)
+  mbox:sync()
+
+  if user.username ~= event.from_address then
+    -- Incoming message
+    if not contains(event.keywords, "$Auto") then
+      -- Not an Auto-Submitted message, notifying.
+
+      -- Notify METADATA server about new message.
+      mbox:metadata_set("/private/messagenew", "")
+    end
+  end
+
+  mbox:free()
+end
+
+function dovecot_lua_notify_end_txn(ctx, success)
+end


### PR DESCRIPTION
This PR enables `push_notification` Dovecot plugin and adds IMAP METADATA backend server in Python to store device tokens for notifications.

For the [driver](https://doc.dovecot.org/configuration_manual/push_notification/#drivers) we use [Lua](https://doc.dovecot.org/configuration_manual/push_notification/#lua-lua) and notify localhost daemon (also acting as METADATA dictionary, see #185) over HTTP about MessageNew events.

When a new message arrives Lua script "sets" `/private/messagenew` metadata to trigger sending notification to https://github.com/deltachat/notifiers via https://notifications.delta.chat/notify endpoint to deliver notification for Apple devices.
Notification happens when `/private/messagenew` is set. When a new message arrives to INBOX Lua plugin for push_notification will do `SETMETADATA INBOX /private/messagenew ""` by calling https://doc.dovecot.org/admin_manual/lua/#mail_user.metadata_set which will trigger sending previously set devicetoken to `notifiers`.

Subscribing to notifications works by doing `SETMETADATA` on the folder:
```
? SETMETADATA INBOX (/private/devicetoken foobar)
```

Core PR where setting device ID via metadata is going to be implemented: https://github.com/deltachat/deltachat-core-rust/pull/5286

---

Lua gets `mail_user` in https://doc.dovecot.org/configuration_manual/push_notification/#dovecot_lua_notify_begin_txn
Then it is possible to get any necessary metadata from https://doc.dovecot.org/admin_manual/lua/#mail_user.metadata_get
and if https://doc.dovecot.org/configuration_manual/push_notification/#dovecot_lua_notify_event_message_new is called, give notification to the local daemon via HTTP so it can forward to https://github.com/deltachat/notifiers.