### PR TITLE
Switch SPF from fail to softfail (`~all` instead of `-all`)

### DIFF
--- a/cmdeploy/src/cmdeploy/chatmail.zone.f
+++ b/cmdeploy/src/cmdeploy/chatmail.zone.f
@@ -6,7 +6,7 @@ _submissions._tcp.{chatmail_domain}. SRV 0 1 465 {chatmail_domain}.
 _imap._tcp.{chatmail_domain}.        SRV 0 1 143 {chatmail_domain}.
 _imaps._tcp.{chatmail_domain}.       SRV 0 1 993 {chatmail_domain}.
 {chatmail_domain}.                   CAA 128 issue "letsencrypt.org;accounturi={acme_account_url}"
-{chatmail_domain}.                   TXT "v=spf1 a:{chatmail_domain} -all"
+{chatmail_domain}.                   TXT "v=spf1 a:{chatmail_domain} ~all"
 _dmarc.{chatmail_domain}.            TXT "v=DMARC1;p=reject;adkim=s;aspf=s"
 _mta-sts.{chatmail_domain}.          TXT "v=STSv1; id={sts_id}"
 mta-sts.{chatmail_domain}.           CNAME {chatmail_domain}.


### PR DESCRIPTION
This is recommended to prevent SPF failure
from rejecting the message early in case messages
are remailed without breaking DKIM.

Closes #211 