### PR TITLE
DKIM-sign Content-Type and oversign all signed headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
 - dovecot: enable gzip compression on disk
   ([#341](https://github.com/deltachat/chatmail/pull/341))
 
+- DKIM-sign Content-Type and oversign all signed headers
+  ([#296](https://github.com/deltachat/chatmail/pull/296))
+
 ## 1.3.0 - 2024-06-06
 
 - don't check necessary DNS records on cmdeploy init anymore

--- a/cmdeploy/src/cmdeploy/opendkim/opendkim.conf
+++ b/cmdeploy/src/cmdeploy/opendkim/opendkim.conf
@@ -25,7 +25,24 @@ KeyTable          /etc/dkimkeys/KeyTable
 SigningTable      refile:/etc/dkimkeys/SigningTable
 
 # Sign Autocrypt header in addition to the default specified in RFC 6376.
-SignHeaders *,+autocrypt
+#
+# Default list is here:
+# <https://github.com/trusteddomainproject/OpenDKIM/blob/5c539587561785a66c1f67f720f2fb741f320785/libopendkim/dkim.c#L221-L245>
+SignHeaders *,+autocrypt,+content-type
+
+# Prevent addition of second Content-Type header
+# and other important headers that should not be added
+# after signing the message.
+# See
+# <https://www.zone.eu/blog/2024/05/17/bimi-and-dmarc-cant-save-you/>
+# and RFC 6376 (page 41) for reference.
+#
+# We don't use "l=" body length so the problem described in RFC 6376
+# is not applicable, but adding e.g. a second "From" header
+# or second "Autocrypt" header is better prevented in any case.
+#
+# Default is empty.
+OversignHeaders from,reply-to,subject,date,to,cc,resent-date,resent-from,resent-sender,resent-to,resent-cc,in-reply-to,references,list-id,list-help,list-unsubscribe,list-subscribe,list-post,list-owner,list-archive,autocrypt
 
 # Script to ignore signatures that do not correspond to the From: domain.
 ScreenPolicyScript /etc/opendkim/screen.lua


### PR DESCRIPTION
Oversigning (including header name in DKIM-Signature
more times that it appears in the mail) prevents
adding more headers with the same name
without invalidating DKIM signature.

We don't want middleboxes to insert a second From header,
adding Cc field to mails that don't have one etc.
