### PR TITLE
filtermail: do not allow ASCII armor without actual payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Increase number of logged in IMAP sessions to 50000
   ([#335](https://github.com/deltachat/chatmail/pull/335))
 
+- filtermail: do not allow ASCII armor without actual payload
+  ([#325](https://github.com/deltachat/chatmail/pull/325))
+
 ## 1.3.0 - 2024-06-06
 
 - don't check necessary DNS records on cmdeploy init anymore

--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -70,6 +70,9 @@ def check_openpgp_payload(payload: bytes):
             # Symmetric-Key Encrypted Session Key Packet (SKESK)
             return False
 
+    if i == 0:
+        return False
+
     if i > len(payload):
         # Payload is truncated.
         return False

--- a/chatmaild/src/chatmaild/tests/test_filtermail.py
+++ b/chatmaild/src/chatmaild/tests/test_filtermail.py
@@ -167,3 +167,19 @@ UN4fiB0KR9JyG2ayUdNJVkXZSZLnHyRgiaadlpUo16LVvw==\r
 """
 
     assert check_armored_payload(payload) == True
+
+    payload = """-----BEGIN PGP MESSAGE-----\r
+\r
+HELLOWORLD
+-----END PGP MESSAGE-----\r
+\r
+"""
+    assert check_armored_payload(payload) == False
+
+    payload = """-----BEGIN PGP MESSAGE-----\r
+\r
+=njUN
+-----END PGP MESSAGE-----\r
+\r
+"""
+    assert check_armored_payload(payload) == False


### PR DESCRIPTION
Last line is removed as "optional checksum",
so it can contain anything.
Make sure that there is at least some actual payload besides this line.