### PR TITLE
Remove sieve to enable hardlink deduplication in LMTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - filtermail: do not allow ASCII armor without actual payload
   ([#325](https://github.com/deltachat/chatmail/pull/325))
 
+- Remove sieve to enable hardlink deduplication in LMTP
+  ([#343](https://github.com/deltachat/chatmail/pull/343))
+
+
 ## 1.3.0 - 2024-06-06
 
 - don't check necessary DNS records on cmdeploy init anymore

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -338,20 +338,6 @@ def _configure_dovecot(config: Config, debug: bool = False) -> bool:
     )
     need_restart |= lua_push_notification_script.changed
 
-    sieve_script = files.put(
-        src=importlib.resources.files(__package__).joinpath("dovecot/default.sieve"),
-        dest="/etc/dovecot/default.sieve",
-        user="root",
-        group="root",
-        mode="644",
-    )
-    need_restart |= sieve_script.changed
-    if sieve_script.changed:
-        server.shell(
-            name="compile sieve script",
-            commands=["/usr/bin/sievec /etc/dovecot/default.sieve"],
-        )
-
     files.template(
         src=importlib.resources.files(__package__).joinpath("dovecot/expunge.cron.j2"),
         dest="/etc/cron.d/expunge",
@@ -548,7 +534,7 @@ def deploy_chatmail(config_path: Path) -> None:
 
     apt.packages(
         name="Install Dovecot",
-        packages=["dovecot-imapd", "dovecot-lmtpd", "dovecot-sieve"],
+        packages=["dovecot-imapd", "dovecot-lmtpd"],
     )
 
     apt.packages(

--- a/cmdeploy/src/cmdeploy/dovecot/default.sieve
+++ b/cmdeploy/src/cmdeploy/dovecot/default.sieve
@@ -1,7 +1,0 @@
-require ["imap4flags"];
-
-# flag the message so it doesn't cause a push notification
-
-if header :is ["Auto-Submitted"] ["auto-replied", "auto-generated"] {
-	addflag "$Auto";
-}

--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -115,10 +115,7 @@ protocol lmtp {
   #
   # mail_lua and push_notification_lua are needed for Lua push notification handler.
   # <https://doc.dovecot.org/configuration_manual/push_notification/#configuration>
-  #
-  # Sieve to mark messages that should not be notified as \Seen
-  # <https://doc.dovecot.org/configuration_manual/sieve/configuration/>
-  mail_plugins = $mail_plugins quota mail_lua notify push_notification push_notification_lua sieve
+  mail_plugins = $mail_plugins quota mail_lua notify push_notification push_notification_lua
 }
 
 plugin {
@@ -138,10 +135,6 @@ plugin {
 plugin {
   # <https://doc.dovecot.org/configuration_manual/push_notification/#lua-lua>
   push_notification_driver = lua:file=/etc/dovecot/push_notification.lua
-}
-
-plugin {
-  sieve_default = file:/etc/dovecot/default.sieve
 }
 
 service lmtp {

--- a/cmdeploy/src/cmdeploy/dovecot/push_notification.lua
+++ b/cmdeploy/src/cmdeploy/dovecot/push_notification.lua
@@ -17,12 +17,8 @@ function dovecot_lua_notify_event_message_new(user, event)
 
   if user.username ~= event.from_address then
     -- Incoming message
-    if not contains(event.keywords, "$Auto") then
-      -- Not an Auto-Submitted message, notifying.
-
-      -- Notify METADATA server about new message.
-      mbox:metadata_set("/private/messagenew", "")
-    end
+    -- Notify METADATA server about new message.
+    mbox:metadata_set("/private/messagenew", "")
   end
 
   mbox:free()


### PR DESCRIPTION
    Remove sieve to enable hardlink deduplication in LMTP

    LMTP does not deduplicate messages
    if sieve plugin is used.

    We don't check for Auto-Submitted header anymore
    as iOS application has a notification service
    and should not display "You have a new message".

Fixes #339