### PR TITLE
Multiplex HTTPS, IMAP and SMTP on port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ While this file is present, account creation will be blocked.
 
 [Postfix](http://www.postfix.org/) listens on ports 25 (smtp) and 587 (submission) and 465 (submissions).
 [Dovecot](https://www.dovecot.org/) listens on ports 143 (imap) and 993 (imaps).
-[nginx](https://www.nginx.com/) listens on port 443 (https).
+[nginx](https://www.nginx.com/) listens on port 8443 (https-alt) and 443 (https).
+Port 443 multiplexes HTTPS, IMAP and SMTP using ALPN to redirect connections to ports 8443, 465 or 993.
 [acmetool](https://hlandau.github.io/acmetool/) listens on port 80 (http).
 
 Delta Chat apps will, however, discover all ports and configurations

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -534,7 +534,7 @@ def deploy_chatmail(config_path: Path) -> None:
 
     apt.packages(
         name="Install nginx",
-        packages=["nginx"],
+        packages=["nginx", "libnginx-mod-stream"],
     )
 
     apt.packages(

--- a/cmdeploy/src/cmdeploy/nginx/autoconfig.xml.j2
+++ b/cmdeploy/src/cmdeploy/nginx/autoconfig.xml.j2
@@ -19,6 +19,13 @@
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
+    <incomingServer type="imap">
+      <hostname>{{ config.domain_name }}</hostname>
+      <port>443</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
     <outgoingServer type="smtp">
       <hostname>{{ config.domain_name }}</hostname>
       <port>465</port>
@@ -30,6 +37,13 @@
       <hostname>{{ config.domain_name }}</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>{{ config.domain_name }}</hostname>
+      <port>443</port>
+      <socketType>SSL</socketType>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -1,3 +1,5 @@
+load_module modules/ngx_stream_module.so;
+
 user www-data;
 worker_processes auto;
 pid /run/nginx.pid;
@@ -6,6 +8,21 @@ error_log syslog:server=unix:/dev/log,facility=local3;
 events {
 	worker_connections 768;
 	# multi_accept on;
+}
+
+stream {
+        map $ssl_preread_alpn_protocols $proxy {
+            default 127.0.0.1:8443;
+            ~\bsmtp\b 127.0.0.1:submissions;
+            ~\bimap\b 127.0.0.1:imaps;
+        }
+
+        server {
+                listen 443;
+                listen [::]:443;
+                proxy_pass $proxy;
+                ssl_preread on;
+        }
 }
 
 http {
@@ -26,8 +43,8 @@ http {
 	gzip on;
 
 	server {
-		listen 443 ssl default_server;
-		listen [::]:443 ssl default_server;
+		listen 8443 ssl default_server;
+		listen [::]:8443 ssl default_server;
 
 		root /var/www/html;
 
@@ -78,8 +95,8 @@ http {
 
 	# Redirect www. to non-www
 	server {
-		listen 443 ssl;
-		listen [::]:443 ssl;
+		listen 8443 ssl;
+		listen [::]:8443 ssl;
 		server_name www.{{ config.domain_name }};
 		return 301 $scheme://{{ config.domain_name }}$request_uri;
 		access_log syslog:server=unix:/dev/log,facility=local7;


### PR DESCRIPTION
Services are distinguished based on ALPN.
For example,
    openssl s_client -connect example.org:443 -alpn smtp
gives SMTP connection and
    openssl s_client -connect example.org:443 -alpn imap
gives IMAP connection.