### PR TITLE
nginx: use numbers for upstream ports

### DIFF
--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -13,8 +13,8 @@ events {
 stream {
         map $ssl_preread_alpn_protocols $proxy {
             default 127.0.0.1:8443;
-            ~\bsmtp\b 127.0.0.1:submissions;
-            ~\bimap\b 127.0.0.1:imaps;
+            ~\bsmtp\b 127.0.0.1:465;
+            ~\bimap\b 127.0.0.1:993;
         }
 
         server {


### PR DESCRIPTION
Otherwise nginx fails when user actually tries to connect, logs have errors such as
`invalid port in upstream "127.0.0.1:imaps"`
and
`invalid port in upstream "127.0.0.1:submissions"`.