### PR TITLE
fix: use separate transaction storage for each DictProxy handler

### DIFF
--- a/chatmaild/src/chatmaild/lastlogin.py
+++ b/chatmaild/src/chatmaild/lastlogin.py
@@ -9,10 +9,10 @@ class LastLoginDictProxy(DictProxy):
         super().__init__()
         self.config = config
 
-    def handle_set(self, transaction_id, parts):
+    def handle_set(self, transaction_id, parts, transactions):
         keyname = parts[1].split("/")
         value = parts[2] if len(parts) > 2 else ""
-        addr = self.transactions[transaction_id]["addr"]
+        addr = transactions[transaction_id]["addr"]
         if keyname[0] == "shared" and keyname[1] == "last-login":
             if addr.startswith("echo@"):
                 return
@@ -22,7 +22,7 @@ class LastLoginDictProxy(DictProxy):
             user.set_last_login_timestamp(timestamp)
         else:
             # Transaction failed.
-            self.transactions[transaction_id]["res"] = "F\n"
+            transactions[transaction_id]["res"] = "F\n"
 
 
 def main():

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -62,12 +62,12 @@ class MetadataDictProxy(DictProxy):
         logging.warning(f"lookup ignored: {parts!r}")
         return "N\n"
 
-    def handle_set(self, transaction_id, parts):
+    def handle_set(self, transaction_id, parts, transactions):
         # For documentation on key structure see
         # https://github.com/dovecot/core/blob/main/src/lib-storage/mailbox-attribute.h
         keyname = parts[1].split("/")
         value = parts[2] if len(parts) > 2 else ""
-        addr = self.transactions[transaction_id]["addr"]
+        addr = transactions[transaction_id]["addr"]
         if keyname[0] == "priv" and keyname[2] == self.metadata.DEVICETOKEN_KEY:
             self.metadata.add_token_to_addr(addr, value)
         elif keyname[0] == "priv" and keyname[2] == "messagenew":
@@ -75,10 +75,10 @@ class MetadataDictProxy(DictProxy):
         else:
             # Transaction failed.
             try:
-                self.transactions[transaction_id]["res"] = "F\n"
+                transactions[transaction_id]["res"] = "F\n"
             except KeyError:
                 logging.error(
-                    f"could not mark tx as failed: {transaction_id} {self.transactions}"
+                    f"could not mark tx as failed: {transaction_id} {transactions}"
                 )
 
 

--- a/chatmaild/src/chatmaild/tests/test_doveauth.py
+++ b/chatmaild/src/chatmaild/tests/test_doveauth.py
@@ -72,12 +72,13 @@ def test_nocreate_file(monkeypatch, tmpdir, dictproxy):
 
 
 def test_handle_dovecot_request(dictproxy):
+    transactions = {}
     # Test that password can contain ", ', \ and /
     msg = (
         'Lshared/passdb/laksjdlaksjdlak\\\\sjdlk\\"12j\\\'3l1/k2j3123"'
         "some42123@chat.example.org\tsome42123@chat.example.org"
     )
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, transactions)
     assert res
     assert res[0] == "O" and res.endswith("\n")
     userdata = json.loads(res[1:].strip())

--- a/chatmaild/src/chatmaild/tests/test_lastlogin.py
+++ b/chatmaild/src/chatmaild/tests/test_lastlogin.py
@@ -12,28 +12,30 @@ def test_handle_dovecot_request_last_login(testaddr, example_config):
     authproxy = AuthDictProxy(config=example_config)
     authproxy.lookup_passdb(testaddr, "1l2k3j1l2k3jl123")
 
+    dictproxy_transactions = {}
+
     # Begin transaction
     tx = "1111"
     msg = f"B{tx}\t{testaddr}"
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, dictproxy_transactions)
     assert not res
-    assert dictproxy.transactions == {tx: dict(addr=testaddr, res="O\n")}
+    assert dictproxy_transactions == {tx: dict(addr=testaddr, res="O\n")}
 
     # set last-login info for user
     user = dictproxy.config.get_user(testaddr)
     timestamp = int(time.time())
     msg = f"S{tx}\tshared/last-login/{testaddr}\t{timestamp}"
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, dictproxy_transactions)
     assert not res
-    assert len(dictproxy.transactions) == 1
+    assert len(dictproxy_transactions) == 1
     read_timestamp = user.get_last_login_timestamp()
     assert read_timestamp == timestamp // 86400 * 86400
 
     # finish transaction
     msg = f"C{tx}"
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, dictproxy_transactions)
     assert res == "O\n"
-    assert len(dictproxy.transactions) == 0
+    assert len(dictproxy_transactions) == 0
 
 
 def test_handle_dovecot_request_last_login_echobot(example_config):
@@ -44,17 +46,19 @@ def test_handle_dovecot_request_last_login_echobot(example_config):
     authproxy.lookup_passdb(testaddr, "ignore")
     user = dictproxy.config.get_user(testaddr)
 
+    transactions = {}
+
     # set last-login info for user
     tx = "1111"
     msg = f"B{tx}\t{testaddr}"
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, transactions)
     assert not res
-    assert dictproxy.transactions == {tx: dict(addr=testaddr, res="O\n")}
+    assert transactions == {tx: dict(addr=testaddr, res="O\n")}
 
     timestamp = int(time.time())
     msg = f"S{tx}\tshared/last-login/{testaddr}\t{timestamp}"
-    res = dictproxy.handle_dovecot_request(msg)
+    res = dictproxy.handle_dovecot_request(msg, transactions)
     assert not res
-    assert len(dictproxy.transactions) == 1
+    assert len(transactions) == 1
     read_timestamp = user.get_last_login_timestamp()
     assert read_timestamp is None


### PR DESCRIPTION
DictProxy can have transactions with the same name (most frequently `1`) processed in parallel.
Dovecot expects that transaction names on each connection are independent.

Fixes #392