### PR TITLE
fix: do not fail with KeyError if there is no acme_account_url

### DIFF
--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -74,7 +74,7 @@ def run_cmd(args, out):
     retcode = out.check_call(cmd, env=env)
     if retcode == 0:
         out.green("Deploy completed, call `cmdeploy dns` next.")
-    elif not remote_data["acme_account_url"]:
+    elif not remote_data.get("acme_account_url"):
         out.red("Deploy completed but letsencrypt not configured")
         out.red("Run 'cmdeploy run' again")
         retcode = 0
@@ -100,7 +100,7 @@ def dns_cmd(args, out):
     if not remote_data:
         return 1
 
-    if not remote_data["acme_account_url"]:
+    if not remote_data.get("acme_account_url"):
         out.red("could not get letsencrypt account url, please run 'cmdeploy run'")
         return 1
 


### PR DESCRIPTION
perform_initial_checks may exit early
and not add `acme_account_url` if required DNS
records are not found.

We should not fail with KeyError if user
runs `cmdeploy dns` on a completely fresh
unconfigured server.