### PR TITLE
Query autoritative nameserver directly to bypass DNS cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- query autoritative nameserver to bypass DNS cache
+  ([#424](https://github.com/deltachat/chatmail/pull/424))
+
 - add mtail support (new optional `mail_address` ini value)
   This defines the address on which [`mtail`](https://google.github.io/mtail/)
   exposes its metrics collected from the logs.


### PR DESCRIPTION
unbound-control is not installed out of the box
and even once installed `flush_zone` does not seem to work reliably.

Instead of trying to flush the cache from unbound, we now query authoritative nameserver directly using `dig`.

Closes #422 