### PR TITLE
Fix OpenPGP payload check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - add IMAP capabilities instead of overwriting them
   ([#413](https://github.com/deltachat/chatmail/pull/413))
 
+- fix OpenPGP payload check
+  ([#435](https://github.com/deltachat/chatmail/pull/435))
+
 
 ## 1.4.1 2024-07-31
 

--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -60,10 +60,11 @@ def check_openpgp_payload(payload: bytes):
         i += body_len
 
         if i == len(payload):
-            if packet_type_id == 18:
-                # Last packet should be
-                # Symmetrically Encrypted and Integrity Protected Data Packet (SEIPD)
-                return True
+            # Last packet should be
+            # Symmetrically Encrypted and Integrity Protected Data Packet (SEIPD)
+            #
+            # This is the only place where this function may return `True`.
+            return packet_type_id == 18
         elif packet_type_id not in [1, 3]:
             # All packets except the last one must be either
             # Public-Key Encrypted Session Key Packet (PKESK)
@@ -71,13 +72,7 @@ def check_openpgp_payload(payload: bytes):
             # Symmetric-Key Encrypted Session Key Packet (SKESK)
             return False
 
-    if i == 0:
-        return False
-
-    if i > len(payload):
-        # Payload is truncated.
-        return False
-    return True
+    return False
 
 
 def check_armored_payload(payload: str):

--- a/chatmaild/src/chatmaild/tests/mail-data/literal.eml
+++ b/chatmaild/src/chatmaild/tests/mail-data/literal.eml
@@ -1,44 +1,44 @@
-From: {from_addr}
-To: {to_addr}
-Subject: ...
-Date: Sun, 15 Oct 2023 16:43:21 +0000
-Message-ID: <Mr.UVyJWZmkCKM.hGzNc6glBE_@c2.testrun.org>
-In-Reply-To: <Mr.MvmCz-GQbi_.6FGRkhDf05c@c2.testrun.org>
-References: <Mr.3gckbNy5bch.uK3Hd2Ws6-w@c2.testrun.org>
-	<Mr.MvmCz-GQbi_.6FGRkhDf05c@c2.testrun.org>
-Chat-Version: 1.0
-Autocrypt: addr={from_addr}; prefer-encrypt=mutual;
-	keydata=xjMEZSwWjhYJKwYBBAHaRw8BAQdAQBEhqeJh0GueHB6kF/DUQqYCxARNBVokg/AzT+7LqH
-	rNFzxiYXJiYXpAYzIudGVzdHJ1bi5vcmc+wosEEBYIADMCGQEFAmUsFo4CGwMECwkIBwYVCAkKCwID
-	FgIBFiEEFTfUNvVnY3b9F7yHnmme1PfUhX8ACgkQnmme1PfUhX9A4AEAnHWHp49eBCMHK5t66gYPiW
-	XQuB1mwUjzGfYWB+0RXUoA/0xcQ3FbUNlGKW7Blp6eMFfViv6Mv2d3kNSXACB6nmcMzjgEZSwWjhIK
-	KwYBBAGXVQEFAQEHQBpY5L2M1XHo0uxf8SX1wNLBp/OVvidoWHQF2Jz+kJsUAwEIB8J4BBgWCAAgBQ
-	JlLBaOAhsMFiEEFTfUNvVnY3b9F7yHnmme1PfUhX8ACgkQnmme1PfUhX/INgEA37AJaNvruYsJVanP
-	IXnYw4CKd55UAwl8Zcy+M2diAbkA/0fHHcGV4r78hpbbL1Os52DPOdqYQRauIeJUeG+G6bQO
-MIME-Version: 1.0
-Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
-	boundary="YFrteb74qSXmggbOxZL9dRnhymywAi"
-
-
---YFrteb74qSXmggbOxZL9dRnhymywAi
-Content-Description: PGP/MIME version identification
-Content-Type: application/pgp-encrypted
-
-Version: 1
-
-
---YFrteb74qSXmggbOxZL9dRnhymywAi
-Content-Description: OpenPGP encrypted message
-Content-Disposition: inline; filename="encrypted.asc";
-Content-Type: application/octet-stream; name="encrypted.asc"
-
------BEGIN PGP MESSAGE-----
-
-yxJiAAAAAABIZWxsbyB3b3JsZCE=
-=1I/B
------END PGP MESSAGE-----
-
-
---YFrteb74qSXmggbOxZL9dRnhymywAi--
-
+From: {from_addr}
+To: {to_addr}
+Subject: ...
+Date: Sun, 15 Oct 2023 16:43:21 +0000
+Message-ID: <Mr.UVyJWZmkCKM.hGzNc6glBE_@c2.testrun.org>
+In-Reply-To: <Mr.MvmCz-GQbi_.6FGRkhDf05c@c2.testrun.org>
+References: <Mr.3gckbNy5bch.uK3Hd2Ws6-w@c2.testrun.org>
+	<Mr.MvmCz-GQbi_.6FGRkhDf05c@c2.testrun.org>
+Chat-Version: 1.0
+Autocrypt: addr={from_addr}; prefer-encrypt=mutual;
+	keydata=xjMEZSwWjhYJKwYBBAHaRw8BAQdAQBEhqeJh0GueHB6kF/DUQqYCxARNBVokg/AzT+7LqH
+	rNFzxiYXJiYXpAYzIudGVzdHJ1bi5vcmc+wosEEBYIADMCGQEFAmUsFo4CGwMECwkIBwYVCAkKCwID
+	FgIBFiEEFTfUNvVnY3b9F7yHnmme1PfUhX8ACgkQnmme1PfUhX9A4AEAnHWHp49eBCMHK5t66gYPiW
+	XQuB1mwUjzGfYWB+0RXUoA/0xcQ3FbUNlGKW7Blp6eMFfViv6Mv2d3kNSXACB6nmcMzjgEZSwWjhIK
+	KwYBBAGXVQEFAQEHQBpY5L2M1XHo0uxf8SX1wNLBp/OVvidoWHQF2Jz+kJsUAwEIB8J4BBgWCAAgBQ
+	JlLBaOAhsMFiEEFTfUNvVnY3b9F7yHnmme1PfUhX8ACgkQnmme1PfUhX/INgEA37AJaNvruYsJVanP
+	IXnYw4CKd55UAwl8Zcy+M2diAbkA/0fHHcGV4r78hpbbL1Os52DPOdqYQRauIeJUeG+G6bQO
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
+	boundary="YFrteb74qSXmggbOxZL9dRnhymywAi"
+
+
+--YFrteb74qSXmggbOxZL9dRnhymywAi
+Content-Description: PGP/MIME version identification
+Content-Type: application/pgp-encrypted
+
+Version: 1
+
+
+--YFrteb74qSXmggbOxZL9dRnhymywAi
+Content-Description: OpenPGP encrypted message
+Content-Disposition: inline; filename="encrypted.asc";
+Content-Type: application/octet-stream; name="encrypted.asc"
+
+-----BEGIN PGP MESSAGE-----
+
+yxJiAAAAAABIZWxsbyB3b3JsZCE=
+=1I/B
+-----END PGP MESSAGE-----
+
+
+--YFrteb74qSXmggbOxZL9dRnhymywAi--
+
 


### PR DESCRIPTION
Replace \r\r\n in literal.eml test with \r\n
to make `test_filtermail_no_literal_packets`
actually reach `check_openpgp_payload()`
and make `check_openpgp_payload()` more strict.

Closes #433