### PR TITLE
fix: increase `request_queue_size` for UNIX sockets to 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- increase `request_queue_size` for UNIX sockets to 1000.
+  ([#437](https://github.com/deltachat/chatmail/pull/437))
+
 - query autoritative nameserver to bypass DNS cache
   ([#424](https://github.com/deltachat/chatmail/pull/424))
 

--- a/chatmaild/src/chatmaild/dictproxy.py
+++ b/chatmaild/src/chatmaild/dictproxy.py
@@ -87,8 +87,12 @@ class DictProxy:
         except FileNotFoundError:
             pass
 
-        with ThreadingUnixStreamServer(socket, Handler) as server:
+        with CustomThreadingUnixStreamServer(socket, Handler) as server:
             try:
                 server.serve_forever()
             except KeyboardInterrupt:
                 pass
+
+
+class CustomThreadingUnixStreamServer(ThreadingUnixStreamServer):
+    request_queue_size = 1000


### PR DESCRIPTION
Default value is 5.
This setting was lost during refactoring in commit bf0f6e230352b9a05fa5b2e4ce59e511731f412e

Closes #436 