### PR TITLE
Remove unnecessary opendkim milter from reinjecting smtpd

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -81,7 +81,6 @@ filter    unix -        n       n       -       -       lmtp
 # Local SMTP server for reinjecting filered mail.
 localhost:{{ config.postfix_reinject_port }} inet  n       -       n       -       10      smtpd
   -o syslog_name=postfix/reinject
-  -o smtpd_milters=unix:opendkim/opendkim.sock
   -o cleanup_service_name=authclean
 
 # Cleanup `Received` headers for authenticated mail


### PR DESCRIPTION
OpenDKIM milter is only needed on port 25,
it seems to do nothing on reinjecting port.