### PR TITLE
Pass through `original_content` instead of `content` in filtermail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Pass through `original_content` instead of `content` in filtermail
+  ([#509](https://github.com/chatmail/server/pull/509))
+
 - Document TLS requirements in the readme
   ([#514](https://github.com/chatmail/server/pull/514))
 

--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -196,7 +196,9 @@ class BeforeQueueHandler:
             return error
         logging.info("re-injecting the mail that passed checks")
         client = SMTPClient("localhost", self.config.postfix_reinject_port)
-        client.sendmail(envelope.mail_from, envelope.rcpt_tos, envelope.content)
+        client.sendmail(
+            envelope.mail_from, envelope.rcpt_tos, envelope.original_content
+        )
         return "250 OK"
 
     def check_DATA(self, envelope):


### PR DESCRIPTION
This avoids unnecessary UTF-8 recoding and passes bytestring through.