### PR TITLE
DNS: add 9.9.9.9 to resolv.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - unbound: check that port 53 is not occupied by a different process
   ([#537](https://github.com/chatmail/server/pull/537))
 
+- unbound: before unbound is there, use 9.9.9.9 for resolving
+  ([#518](https://github.com/chatmail/relay/pull/518))
+
 - Limit the bind for the HTTPS server on 8443 to 127.0.0.1 
   ([#522](https://github.com/chatmail/server/pull/522))
   ([#532](https://github.com/chatmail/server/pull/532))

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -592,6 +592,12 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
         ensure_newline=True,
     )
 
+    if host.get_fact(Port, port=53) != "unbound":
+        files.line(
+            name="Add 9.9.9.9 to resolv.conf",
+            path="/etc/resolv.conf",
+            line="nameserver 9.9.9.9",
+        )
     apt.update(name="apt update", cache_time=24 * 3600)
     apt.upgrade(name="upgrade apt packages", auto_remove=True)
 


### PR DESCRIPTION
According to #515, some providers misconfigure /etc/resolv.conf. With 9.9.9.9, at least one working DNS resolver is there.