### PR TITLE
fix: send SNI when connecting to outside servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Send SNI when connecting to outside servers
+  ([#524](https://github.com/chatmail/server/pull/524))
+
 - Pass through `original_content` instead of `content` in filtermail
   ([#509](https://github.com/chatmail/server/pull/509))
 

--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -21,6 +21,9 @@ smtpd_tls_security_level=may
 
 smtp_tls_CApath=/etc/ssl/certs
 smtp_tls_security_level=verify
+# Send SNI extension when connecting to other servers.
+# <https://www.postfix.org/postconf.5.html#smtp_tls_servername>
+smtp_tls_servername = hostname
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtp_tls_policy_maps = inline:{nauta.cu=may}
 smtpd_tls_protocols = >=TLSv1.2


### PR DESCRIPTION
Otherwise email providers which allow to bring your own domain and use the same IP addresses for all customers
send wildcard certificate instead of the correct one and Postfix refuses to connect with an error

    server certificate verification failed for example.org[A.B.C.D]:25: num=62:hostname mismatch

Closes #523 