### PR TITLE
Postfix master.cf: use 127.0.0.1 for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Send SNI when connecting to outside servers
   ([#524](https://github.com/chatmail/server/pull/524))
 
+- postfix master.cf: use 127.0.0.1 for consistency
+  ([#544](https://github.com/chatmail/relay/pull/544))
+
 - Pass through `original_content` instead of `content` in filtermail
   ([#509](https://github.com/chatmail/server/pull/509))
 

--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -77,13 +77,13 @@ scache    unix  -       -       y       -       1       scache
 postlog   unix-dgram n  -       n       -       1       postlogd
 filter    unix -        n       n       -       -       lmtp
 # Local SMTP server for reinjecting outgoing filtered mail.
-localhost:{{ config.postfix_reinject_port }} inet  n       -       n       -       10      smtpd
+127.0.0.1:{{ config.postfix_reinject_port }} inet  n       -       n       -       10      smtpd
   -o syslog_name=postfix/reinject
   -o smtpd_milters=unix:opendkim/opendkim.sock
   -o cleanup_service_name=authclean
 
 # Local SMTP server for reinjecting incoming filtered mail 
-localhost:{{ config.postfix_reinject_port_incoming }} inet  n       -       n       -       10      smtpd
+127.0.0.1:{{ config.postfix_reinject_port_incoming }} inet  n       -       n       -       10      smtpd
   -o syslog_name=postfix/reinject_incoming
   -o smtpd_milters=unix:opendkim/opendkim.sock
 


### PR DESCRIPTION
Elsewhere in the master.cf we intentionally use 127.0.0.1 instead of localhost which is useful because it's possible that sometimes it could initially fail if IPv6 is enabled on the OS but these services are not bound to ::1