### PR TITLE
add a hint that deletion may be earlier

### DIFF
--- a/www/src/info.md
+++ b/www/src/info.md
@@ -15,9 +15,10 @@ for the usage in chats, especially DeltaChat.
 
 - You may send up to {{ config.max_user_send_per_minute }} messages per minute.
 
-- Messages are unconditionally removed {{ config.delete_mails_after }} days after arriving on the server.
-
 - You can store up to [{{ config.max_mailbox_size }} messages on the server](https://delta.chat/en/help#what-happens-if-i-turn-on-delete-old-messages-from-server).
+
+- Messages are unconditionally removed latest {{ config.delete_mails_after }} days after arriving on the server.
+  Earlier, if storage may exceed otherwise.
 
 
 ### <a name="account-deletion"></a> Account deletion 


### PR DESCRIPTION
there is another mention of times in privacy.md,
however, there the gist is about that things are deleted, it is fine if that happens earlier there (also it is not excluded).

targets discussion from https://github.com/chatmail/relay/pull/504