### PR TITLE
cmdeploy: on ubuntu/debian, test if python3-dev is installed

### DIFF
--- a/scripts/initenv.sh
+++ b/scripts/initenv.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [[ $(lsb_release -is 2> /dev/null) == "Ubuntu" || $(lsb_release -is 2> /dev/null) == "Debian" ]]
+then
+  if [ $(dpkg -l | grep python3-dev 2>&1 /dev/null) ]
+  then
+    echo "You need to install python3-dev for installing the other dependencies."
+    exit 1
+  fi
+fi
+
 python3 -m venv --upgrade-deps venv
 
 venv/bin/pip install -e chatmaild 


### PR DESCRIPTION
fix #561

This gives slightly better advice, I'm not sure if installing this automatically is a good idea.