### PR TITLE
avoid crash on spurious empty file in the pending_notifications dir

### DIFF
--- a/chatmaild/src/chatmaild/notifier.py
+++ b/chatmaild/src/chatmaild/notifier.py
@@ -95,7 +95,12 @@ class Notifier:
                 logging.warning(f"removing spurious queue item: {queue_path!r}")
                 queue_path.unlink()
                 continue
-            queue_item = PersistentQueueItem.read_from_path(queue_path)
+            try:
+                queue_item = PersistentQueueItem.read_from_path(queue_path)
+            except ValueError:
+                logging.warning(f"removing spurious queue item: {queue_path!r}")
+                queue_path.unlink()
+                continue
             self.queue_for_retry(queue_item)
 
     def queue_for_retry(self, queue_item, retry_num=0):


### PR DESCRIPTION
I wanted to create `enforceE2EEincoming` for every maildir folder in `/home/vmail/mail/DOMAIN/` I was not aware that there is a `pending_notifications` folder there, hard to realize when you have hundreds of folders there, it could happen to other people in general is better to be more resilient and just ignore such invalid files and delete them instead of crashing forever, dovecot process will fail badly then trying to connect to an nonexistent `/run/chatmail-metadata/metadata.socket`