### PR TITLE
cmdeploy: upload chatmail/relay version to /etc 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ Please fill out as much of this form as you can (leaving out stuff that is not a
 
 - Server OS (Operating System) - preferably Debian 12: 
 - On which OS you run cmdeploy:
+- chatmail/relay version: `git rev-parse HEAD`
 
 ## Expected behavior
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add config value after how many days large files are deleted
   ([#555](https://github.com/chatmail/relay/pull/555))
 
+- cmdeploy: push relay version to /etc/chatmail-version
+  ([#573](https://github.com/chatmail/relay/pull/573))
+
 - filtermail: allow partial body length in OpenPGP payloads
   ([#570](https://github.com/chatmail/relay/pull/570))
 

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -367,7 +367,7 @@ def _configure_dovecot(config: Config, debug: bool = False) -> bool:
         if host.get_fact(Sysctl)[key] > 65535:
             # Skip updating limits if already sufficient
             # (enables running in incus containers where sysctl readonly)
-            continue 
+            continue
         server.sysctl(
             name=f"Change {key}",
             key=key,

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -761,7 +761,7 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
     git_diff = subprocess.check_output(["git", "diff"]).decode()
     files.put(
-        name="Upload chatmail relay version",
+        name="Upload chatmail relay git commiit hash",
         src=StringIO(git_hash + git_diff),
         dest="/etc/chatmail-version",
         mode="700",

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -7,6 +7,7 @@ import io
 import shutil
 import subprocess
 import sys
+from io import StringIO
 from pathlib import Path
 
 from chatmaild.config import Config, read_config
@@ -756,6 +757,14 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     apt.packages(
         name="Ensure cron is installed",
         packages=["cron"],
+    )
+    git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
+    git_diff = subprocess.check_output(["git", "diff"]).decode()
+    files.put(
+        name="Upload chatmail relay version",
+        src=StringIO(git_hash + git_diff),
+        dest="/etc/chatmail-version",
+        mode="700",
     )
 
     deploy_mtail(config)

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -118,7 +118,9 @@ def test_authenticated_from(cmsetup, maildata):
 @pytest.mark.parametrize("from_addr", ["fake@example.org", "fake@testrun.org"])
 def test_reject_missing_dkim(cmsetup, maildata, from_addr):
     recipient = cmsetup.gen_users(1)[0]
-    msg = maildata("encrypted.eml", from_addr=from_addr, to_addr=recipient.addr).as_string()
+    msg = maildata(
+        "encrypted.eml", from_addr=from_addr, to_addr=recipient.addr
+    ).as_string()
     try:
         conn = smtplib.SMTP(cmsetup.maildomain, 25, timeout=10)
     except TimeoutError:
@@ -183,7 +185,9 @@ def test_expunged(remote, chatmail_config):
         f"find {chatmail_config.mailboxes_dir} -path '*/.*/tmp/*' -mtime +{outdated_days} -type f",
     ]
     outdated_days = int(chatmail_config.delete_large_after) + 1
-    find_cmds.append("find {chatmail_config.mailboxes_dir} -path '*/cur/*' -mtime +{outdated_days} -size +200k -type f")
+    find_cmds.append(
+        "find {chatmail_config.mailboxes_dir} -path '*/cur/*' -mtime +{outdated_days} -size +200k -type f"
+    )
     for cmd in find_cmds:
         for line in remote.iter_output(cmd):
             assert not line

--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -307,6 +307,7 @@ def cmfactory(request, gencreds, tmpdir, maildomain):
     class Data:
         def read_path(self, path):
             return
+
     am = ACFactory(request=request, tmpdir=tmpdir, testprocess=testproc, data=Data())
 
     # nb. a bit hacky


### PR DESCRIPTION
This makes it easier to see which changes have already been deployed.