### PR TITLE
feat: Add try blocks around Git commands in cmdeploy/__init__.py

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -816,8 +816,14 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
         name="Ensure cron is installed",
         packages=["cron"],
     )
-    git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
-    git_diff = subprocess.check_output(["git", "diff"]).decode()
+    try:
+        git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
+    except Exception:
+        git_hash = "unknown\n"
+    try:
+        git_diff = subprocess.check_output(["git", "diff"]).decode()
+    except Exception:
+        git_diff = ""
     files.put(
         name="Upload chatmail relay git commiit hash",
         src=StringIO(git_hash + git_diff),


### PR DESCRIPTION
- Added 'try' blocks around the 'git rev-parse' and 'git diff' commands that are run in deploy_chatmail().  If there is an error running rev-parse, git_hash is set to "unknown".  If there is an error running diff, git_diff is set to the null string.
- This allows the deployment process work in two scenarios that would otherwise fail with an exception:
    - Systems where the 'git' command is not available.
    - When running with a copy of the tree content of chatmail/relay, but without a copy of the .git directory.