### PR TITLE
feat: Check whether GCC is installed in initenv.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Check whether GCC is installed in initenv.sh
+  ([#608](https://github.com/chatmail/relay/pull/608))
+
 - Expire push notification tokens after 90 days
   ([#583](https://github.com/chatmail/relay/pull/583))
 

--- a/scripts/initenv.sh
+++ b/scripts/initenv.sh
@@ -9,9 +9,9 @@ if command -v lsb_release 2>&1 >/dev/null; then
         echo "You need to install python3-dev for installing the other dependencies."
         exit 1
       fi
-      if ! dpkg -l | grep build-essential 2>&1 >/dev/null
+      if ! gcc --version 2>&1 >/dev/null
       then
-        echo "You need to install build-essential for building Python dependencies."
+        echo "You need to install gcc for building Python dependencies."
         exit 1
       fi
       ;;

--- a/scripts/initenv.sh
+++ b/scripts/initenv.sh
@@ -9,6 +9,11 @@ if command -v lsb_release 2>&1 >/dev/null; then
         echo "You need to install python3-dev for installing the other dependencies."
         exit 1
       fi
+      if ! dpkg -l | grep build-essential 2>&1 >/dev/null
+      then
+        echo "You need to install build-essential for building Python dependencies."
+        exit 1
+      fi
       ;;
   esac
 fi


### PR DESCRIPTION
- The Python modules installed by initenv.sh require a compiler to build.
- Before proceeding with installation of Python dependencies, check whether the 'gcc' command is available by running it with the --version argument.  If it is not available, print a helpful message and exit.