### PR TITLE
docs: Add ARCHITECTURE.md with diagram of components

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,5 @@
-This diagram shows components of the chatmail server:
+This diagram shows components of the chatmail server; this is a draft
+overview as of mid-August 2025:
 
 ```mermaid
 graph LR;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,36 +3,48 @@ overview as of mid-August 2025:
 
 ```mermaid
 graph LR;
-    cmdeploy --> sshd;
-    cron --> expunge;
-    cron --> acmetool;
-    cron --> chatmail-metrics;
-    chatmail-metrics --> /var/www/html;
-    acmetool --> certs;
-    acmetool --> acmetool-redirector;
-    acmetool-redirector --> certs;
-    nginx --> /var/www/html;
-    nginx --> certs;
-    nginx --> newemail.py;
-    nginx --> |465|postfix;
-    nginx --> autoconfig.xml;
-    nginx --> |993|dovecot;
-    autoconfig.xml --> postfix;
-    autoconfig.xml --> dovecot;
-    postfix --> certs;
-    postfix --> /home/vmail/mail;
-    postfix --> |10080,10081|filtermail;
-    postfix --> echobot;
-    postfix --> |doveauth.socket|doveauth;
-    dovecot --> certs;
-    dovecot --> |doveauth.socket|doveauth;
-    dovecot --> /home/vmail/mail;
-    dovecot --> |metadata.socket|chatmail-metadata;
-    doveauth --> /home/vmail/mail;
-    expunge --> /home/vmail/mail;
-    chatmail-metadata --> iroh-relay;
+    cmdeploy --- sshd;
+    letsencrypt --- |80|acmetool-redirector;
+    acmetool-redirector --- |443|nginx-right(["`nginx
+    (external)`"]);
+    nginx-external --- |465|postfix;
+    nginx-external(["`nginx
+    (external)`"]) --- |8443|nginx-internal["`nginx
+    (internal)`"];
+    nginx-internal --- website["`Website
+    /var/www/html`"];
+    nginx-internal --- newemail.py;
+    nginx-internal --- autoconfig.xml;
+    certs-nginx[("`TLS certs
+    /var/lib/acme`")] --> nginx-internal;
+    cron --- chatmail-metrics;
+    cron --- acmetool;
+    cron --- expunge;
+    chatmail-metrics --- website;
+    acmetool --> certs[("`TLS certs
+    /var/lib/acme`")];
+    nginx-external --- |993|dovecot;
+    autoconfig.xml --- postfix;
+    autoconfig.xml --- dovecot;
+    postfix --- echobot;
+    postfix --- |10080,10081|filtermail;
+    postfix --- users["`User data
+    home/vmail/mail`"];
+    postfix --- |doveauth.socket|doveauth;
+    dovecot --- |doveauth.socket|doveauth;
+    dovecot --- users;
+    dovecot --- |metadata.socket|chatmail-metadata;
+    doveauth --- users;
+    expunge --- users;
+    chatmail-metadata --- iroh-relay;
+    certs-nginx --> postfix;
+    certs-nginx --> dovecot;
+    style certs fill:#ff6;
+    style certs-nginx fill:#ff6;
+    style nginx-external fill:#fc9;
+    style nginx-right fill:#fc9;
 ```
 
-(Arrows in this diagram do not have a specific formal meaning; they
-signify "depends on", or "uses", or "sends data to", or just "relates
-to".)
+The edges in this graph should not be taken too literally; they
+reflect some sort of communication path or dependency relationship
+between components of the chatmail server.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,37 @@
+This diagram shows components of the chatmail server:
+
+```mermaid
+graph LR;
+    cmdeploy --> sshd;
+    cron --> expunge;
+    cron --> acmetool;
+    cron --> chatmail-metrics;
+    chatmail-metrics --> /var/www/html;
+    acmetool --> certs;
+    acmetool --> acmetool-redirector;
+    acmetool-redirector --> certs;
+    nginx --> /var/www/html;
+    nginx --> certs;
+    nginx --> newemail.py;
+    nginx --> |465|postfix;
+    nginx --> autoconfig.xml;
+    nginx --> |993|dovecot;
+    autoconfig.xml --> postfix;
+    autoconfig.xml --> dovecot;
+    postfix --> certs;
+    postfix --> /home/vmail/mail;
+    postfix --> |10080,10081|filtermail;
+    postfix --> echobot;
+    postfix --> |doveauth.socket|doveauth;
+    dovecot --> certs;
+    dovecot --> |doveauth.socket|doveauth;
+    dovecot --> /home/vmail/mail;
+    dovecot --> |metadata.socket|chatmail-metadata;
+    doveauth --> /home/vmail/mail;
+    expunge --> /home/vmail/mail;
+    chatmail-metadata --> iroh-relay;
+```
+
+(Arrows in this diagram do not have a specific formal meaning; they
+signify "depends on", or "uses", or "sends data to", or just "relates
+to".)


### PR DESCRIPTION
- For starters, this file is just a diagram of components of a chatmail server.  In the future, this document can grow into a more complete description of the architecture of the server, the deployment process, and the design intent behind what is and isn't in the code base.
- The name ARCHITECTURE.md is inspired by this article, which also has good suggestions about what to put in the file: https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html