### PR TITLE
feat: setup TURN server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Setup TURN server
+  ([#621](https://github.com/chatmail/relay/pull/621))
+
 - Update iroh-relay to 0.35.0
   ([#650](https://github.com/chatmail/relay/pull/650))
 

--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -29,6 +29,7 @@ echobot = "chatmaild.echo:main"
 chatmail-metrics = "chatmaild.metrics:main"
 delete_inactive_users = "chatmaild.delete_inactive_users:main"
 lastlogin = "chatmaild.lastlogin:main"
+turnserver = "chatmaild.turnserver:main"
 
 [project.entry-points.pytest11]
 "chatmaild.testplugin" = "chatmaild.tests.plugin"

--- a/chatmaild/src/chatmaild/turnserver.py
+++ b/chatmaild/src/chatmaild/turnserver.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+import socket
+
+
+def turn_credentials() -> str:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client_socket:
+        client_socket.connect("/run/chatmail-turn/turn.socket")
+        with client_socket.makefile("rb") as file:
+            return file.readline().decode("utf-8")

--- a/cmdeploy/src/cmdeploy/iroh-relay.toml
+++ b/cmdeploy/src/cmdeploy/iroh-relay.toml
@@ -1,5 +1,11 @@
 enable_relay = true
 http_bind_addr = "[::]:3340"
-enable_stun = true
+
+# Disable built-in STUN server in iroh-relay 0.35
+# as we deploy our own TURN server instead.
+# STUN server is going to be removed in iroh-relay 1.0
+# and this line can be removed after upgrade.
+enable_stun = false
+
 enable_metrics = false
 metrics_bind_addr = "127.0.0.1:9092"

--- a/cmdeploy/src/cmdeploy/service/turnserver.service.f
+++ b/cmdeploy/src/cmdeploy/service/turnserver.service.f
@@ -1,0 +1,16 @@
+[Unit]
+Description=A wrapper for the TURN server
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/local/bin/chatmail-turn --realm {mail_domain} --socket /run/chatmail-turn/turn.socket
+
+# Create /run/chatmail-turn
+RuntimeDirectory=chatmail-turn
+User=vmail
+Group=vmail
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #619 
Based on #650 

This disables STUN server in iroh-relay and deploys another `coturn` as a STUN/TURN server.

I have tested that online tests using realtime channels still pass against a server that has this deployed. Also tested that "pong" app works between two profiles using the same relay but connected using different Wi-Fi networks, so at least realtime channels are not broken by this.

Corresponding core PR: https://github.com/chatmail/core/pull/7218