### PR TITLE
cmdeploy: suppress SSH login info message

### DIFF
--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -90,7 +90,7 @@ def run_cmd(args, out):
         retcode = out.check_call(cmd, env=env)
         if retcode == 0:
             print("\nYou can try out the relay by talking to this echo bot: ")
-            sshexec = args.get_sshexec()
+            sshexec = SSHExec(args.config.mail_domain, verbose=args.verbose)
             print(
                 sshexec(
                     call=remote.rshell.shell,


### PR DESCRIPTION
Since https://github.com/chatmail/relay/pull/620, at the end of every deployment we print:

```
You can try out the relay by talking to this echo bot: 
[ssh] login to nine.testrun.org
https://i.delta.chat/#7C7AB5485A3C08396DAFF720B9A63A7686BE45B0&a=echo%40nine.testrun.org&n=&i=K1rx92Kg-yJkkqDOSw-qT2CH&s=-5QZgGgGmKh4EyCz2d8kC55K
```

Let's stop printing the second line :)