### PR TITLE
config: add www_folder to default config

### DIFF
--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -45,6 +45,9 @@ passthrough_senders =
 # (space-separated, item may start with "@" to whitelist whole recipient domains)
 passthrough_recipients = xstore@testrun.org echo@{mail_domain}
 
+# path to www directory - documented here: https://github.com/chatmail/relay/#custom-web-pages
+#www_folder = www
+
 #
 # Deployment Details
 #


### PR DESCRIPTION
Maybe it should be discussed actually:

- on `cmdeploy init`, do we want to add all possible config values, or only the necessary ones?
- if we add config values with a default value, should they be commented out?
- where do we document config values? Right now most are documented in chatmail.ini.f, and some in README.md. The former is not obvious for people who upgrade their relay to a version with new config values, the latter might be a bit harder to find for new users.

