### PR TITLE
www: chown /var/www/html to www-data

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -760,7 +760,7 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
         if build_dir:
             www_path = build_webpages(src_dir, build_dir, config)
         # if it is not a hugo page, upload it as is
-        files.rsync(f"{www_path}/", "/var/www/html", flags=["-avz"])
+        files.rsync(f"{www_path}/", "/var/www/html", flags=["-avz", "--chown=www-data"])
 
     _install_remote_venv_with_chatmaild(config)
     debug = False


### PR DESCRIPTION
In many cases, both local user ID and remote www-data user ID are 1000, so we never noticed. 