### PR TITLE
Revert "dovecot: keep mailbox index only in memory (#632)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - Allow ports 143 and 993 to be used by `dovecot` process
   ([#639](https://github.com/chatmail/relay/pull/639))
 
-- dovecot: keep mailbox index only in memory to avoid unnecessary disc usage 
-  ([#632](https://github.com/chatmail/relay/pull/632))
-
 ## 1.7.0 2025-09-11
 
 - Make www upload path configurable

--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -68,7 +68,7 @@ userdb {
 ##
 
 # Mailboxes are stored in the "mail" directory of the vmail user home.
-mail_location = maildir:{{ config.mailboxes_dir }}/%u:INDEX=MEMORY
+mail_location = maildir:{{ config.mailboxes_dir }}/%u
 
 namespace inbox {
   inbox = yes


### PR DESCRIPTION
This reverts commit 7bf2dfd62e169856aa4e13d7cc2234dffa550291.

Closes #640 