### PR TITLE
Use max username length in newemail.py, not min

### DIFF
--- a/chatmaild/src/chatmaild/newemail.py
+++ b/chatmaild/src/chatmaild/newemail.py
@@ -15,7 +15,7 @@ ALPHANUMERIC_PUNCT = string.ascii_letters + string.digits + string.punctuation
 
 
 def create_newemail_dict(config: Config):
-    user = "".join(random.choices(ALPHANUMERIC, k=config.username_min_length))
+    user = "".join(random.choices(ALPHANUMERIC, k=config.username_max_length))
     password = "".join(
         secrets.choice(ALPHANUMERIC_PUNCT)
         for _ in range(config.password_min_length + 3)


### PR DESCRIPTION
- username_min_length and username_max_length are both set to a default value of 9 in the chatmail.ini.f template.  When they have the same value, it doesn't matter which one we use in newemail.py (which handles the /new URL).  However, if they are configured to different values by the admin, then the current implementation using username_min_length chooses from a smaller set of possible usernames.
- Revised create_newemail_dict() in newemail.py to use username_max_length as the length of the random username it offers via the /new URL.  This randomizes within a much larger set of possible usernames.