### PR TITLE
cmdeploy: start and enable fcgiwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Use max username length in newemail.py, not min
   ([#648](https://github.com/chatmail/relay/pull/648))
 
+- Add startup for `fcgiwrap.service` because sometimes it did not start automatically.
+  ([#657](https://github.com/chatmail/relay/pull/657))
+
 - Increase maxproc for reinjecting ports from 10 to 100
   ([#646](https://github.com/chatmail/relay/pull/646))
 

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -814,6 +814,13 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     )
 
     systemd.service(
+        name="Start and enable fcgiwrap",
+        service="fcgiwrap.service",
+        running=True,
+        enabled=True,
+    )
+
+    systemd.service(
         name="Restart echobot if postfix and dovecot were just started",
         service="echobot.service",
         restarted=postfix_need_restart and dovecot_need_restart,


### PR DESCRIPTION
Came up during #614 - fcgiwrap isn't started in some cases. 