### PR TITLE
cmdeploy: add acme_email config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Ignore all RCPT TO: parameters
   ([#651](https://github.com/chatmail/relay/pull/651))
 
+- Add config parameter for Let's Encrypt ACME email
+  ([#663](https://github.com/chatmail/relay/pull/663))
+
 - Use max username length in newemail.py, not min
   ([#648](https://github.com/chatmail/relay/pull/648))
 

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -44,6 +44,7 @@ class Config:
         )
         self.mtail_address = params.get("mtail_address")
         self.disable_ipv6 = params.get("disable_ipv6", "false").lower() == "true"
+        self.acme_email = params.get("acme_email", "")
         self.imap_rawlog = params.get("imap_rawlog", "false").lower() == "true"
         if "iroh_relay" not in params:
             self.iroh_relay = "https://" + params["mail_domain"]

--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -60,6 +60,9 @@ postfix_reinject_port_incoming = 10026
 # if set to "True" IPv6 is disabled
 disable_ipv6 = False
 
+# Your email adress, which will be used in acmetool to manage Let's Encrypt SSL certificates
+acme_email = 
+
 # Defaults to https://iroh.{{mail_domain}} and running `iroh-relay` on the chatmail
 # service.
 # If you set it to anything else, the service will be disabled

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -727,6 +727,7 @@ def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     # Deploy acmetool to have TLS certificates.
     tls_domains = [mail_domain, f"mta-sts.{mail_domain}", f"www.{mail_domain}"]
     deploy_acmetool(
+        email=config.acme_email,
         domains=tls_domains,
     )
 


### PR DESCRIPTION
Pulled out of #614 - we have the setting in our `acmetool` pyinfra module anyway, it makes sense to allow to configure it :)

Not so sure if we want it in our default chatmail.ini, but that rather depends on where we want to document the config values, which is a separate ongoing discussion. For now we have them in the default ini, so maybe we should keep it like this for now, and remove it later when we clean up the default chatmail.ini.