### PR TITLE
Don't print echobot link when disabling mail

### DIFF
--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -109,14 +109,15 @@ def run_cmd(args, out):
     try:
         retcode = out.check_call(cmd, env=env)
         if retcode == 0:
-            print("\nYou can try out the relay by talking to this echo bot: ")
-            sshexec = SSHExec(args.config.mail_domain, verbose=args.verbose)
-            print(
-                sshexec(
-                    call=remote.rshell.shell,
-                    kwargs=dict(command="cat /var/lib/echobot/invite-link.txt"),
+            if not args.disable_mail:
+                print("\nYou can try out the relay by talking to this echo bot: ")
+                sshexec = SSHExec(args.config.mail_domain, verbose=args.verbose)
+                print(
+                    sshexec(
+                        call=remote.rshell.shell,
+                        kwargs=dict(command="cat /var/lib/echobot/invite-link.txt"),
+                    )
                 )
-            )
             out.green("Deploy completed, call `cmdeploy dns` next.")
         elif not remote_data["acme_account_url"]:
             out.red("Deploy completed but letsencrypt not configured")


### PR DESCRIPTION
- On a fresh install, if cmdeploy is run the first time with the --disable-mail option, the echobot invite-link.txt file will not exist yet.
- Only print the echobot invite link if --disable-mail was not specified.  This fixes the fresh-install error case, and also makes sense when disabling mail in general, because the echo bot will not be available at that time.