### PR TITLE
test: Handle Git errors in test_deployed_state()

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -209,8 +209,14 @@ def test_expunged(remote, chatmail_config):
 
 
 def test_deployed_state(remote):
-    git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
-    git_diff = subprocess.check_output(["git", "diff"]).decode()
+    try:
+        git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode()
+    except Exception:
+        git_hash = "unknown\n"
+    try:
+        git_diff = subprocess.check_output(["git", "diff"]).decode()
+    except Exception:
+        git_diff = ""
     git_status = [git_hash.strip()]
     for line in git_diff.splitlines():
         git_status.append(line.strip().lower())


### PR DESCRIPTION
- This is a counterpart to pull request #607.  Revised test_deployed_state() to perform the same error-handling on Git commands that cmdeploy does.  If 'git rev-parse' returns an error, the value "unknown" is used.  If 'git diff' returns an error, the null string is used.
- This fixes failures in environments where Git is not installed or where the .git subdirectory is not present (as long as the server was deployed in the same way).