### PR TITLE
test: Return None for success in test_timezone_env()

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -69,7 +69,7 @@ def test_timezone_env(remote):
     for line in remote.iter_output("env"):
         print(line)
         if line == "tz=:/etc/localtime":
-            return True
+            return
     pytest.fail("TZ is not set")
 
 


### PR DESCRIPTION
- test_timezone_env() is producing the warning, "PytestReturnNotNoneWarning: Test functions should return None, but src/cmdeploy/tests/online/test_1_basic.py::test_timezone_env returned <class 'bool'>".
- Revised test_timezone_env() to return None for success instead of True.