### PR TITLE
opendkim: increase DNSTimeout from 5 (default) to 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Ignore all RCPT TO: parameters
   ([#651](https://github.com/chatmail/relay/pull/651))
 
+- Increase opendkim DNS Timeout from 5 to 60 seconds
+  ([#672](https://github.com/chatmail/relay/pull/672))
+
 - Add config parameter for Let's Encrypt ACME email
   ([#663](https://github.com/chatmail/relay/pull/663))
 

--- a/cmdeploy/src/cmdeploy/opendkim/opendkim.conf
+++ b/cmdeploy/src/cmdeploy/opendkim/opendkim.conf
@@ -13,6 +13,7 @@ OversignHeaders		From
 On-BadSignature         reject
 On-KeyNotFound          reject
 On-NoSignature          reject
+DNSTimeout          60
 
 # Signing domain, selector, and key (required). For example, perform signing
 # for domain "example.com" with selector "2020" (2020._domainkey.example.com),


### PR DESCRIPTION
fix #667

After some days, the delivery issues to chatmail.hackea.org didn't reappear - it seems if the mail server has a slow connection, in can take longer than 5 seconds to request DKIM keys of a sender's mail server.