### PR TITLE
filtermail: run CPU-intensive handle_DATA in a thread pool executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- filtermail: run CPU-intensive handle_DATA in a thread pool executor
+  ([#676](https://github.com/chatmail/relay/pull/676))
+
 - don't use the complicated logging module in filtermail to exclude a potential source of errors. 
   ([#674](https://github.com/chatmail/relay/pull/674))
 

--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -241,6 +241,10 @@ class OutgoingBeforeQueueHandler:
         return "250 OK"
 
     async def handle_DATA(self, server, session, envelope):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.sync_handle_DATA, envelope)
+
+    def sync_handle_DATA(self, envelope):
         log_info("handle_DATA before-queue")
         error = self.check_DATA(envelope)
         if error:
@@ -294,6 +298,10 @@ class IncomingBeforeQueueHandler:
         self.config = config
 
     async def handle_DATA(self, server, session, envelope):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.sync_handle_DATA, envelope)
+
+    def sync_handle_DATA(self, envelope):
         log_info("handle_DATA before-queue")
         error = self.check_DATA(envelope)
         if error:


### PR DESCRIPTION
See
<https://docs.python.org/3/library/asyncio-eventloop.html#executing-code-in-thread-or-process-pools> for the documentation.

This should avoid processing of large messages from hogging asyncio thread and delaying async operations like accepting new connections.

This is addressing #675