### PR TITLE
filtermail: better performance for removing Version

### DIFF
--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -104,7 +104,7 @@ def check_armored_payload(payload: str, outgoing: bool):
     # Disallow comments in outgoing messages
     version_comment = "Version: "
     if payload.startswith(version_comment):
-        splitindex = payload.find("\r\n") + 4
+        splitindex = payload.find("\r\n") + 2
         payload = payload[splitindex:]
         if outgoing:
             return False


### PR DESCRIPTION
This reduces 100,000 calls of `src/chatmaild/tests/test_filtermail.py::test_check_armored_payload` from 11.00 to 10.52 seconds.

Related to #675 