### PR TITLE
filtermail: further optimize check_armored_payload()

### DIFF
--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -106,7 +106,7 @@ def check_armored_payload(payload: str, outgoing: bool):
         if outgoing:  # Disallow comments in outgoing messages
             return False
         # Remove comments from incoming messages
-        payload = payload.split("\r\n", maxsplit=1)[1]
+        payload = payload.partition("\r\n")[2]
 
     while payload.startswith("\r\n"):
         payload = payload.removeprefix("\r\n")


### PR DESCRIPTION
With python3.11 this seems to be the fastest option: https://github.com/chatmail/relay/pull/679#issuecomment-3423431811

All the incoming PGP-encrypted mails with Version headers will be processed so much faster now, a very important and necessary optimization during which we learned a lot about python string operations.