### PR TITLE
Require STARTTLS for incoming port 25 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Require TLS 1.2 for outgoing SMTP connections
   ([#685](https://github.com/chatmail/relay/pull/685))
 
+- require STARTTLS for incoming port 25 connections
+  ([#684](https://github.com/chatmail/relay/pull/684))
+
 - filtermail: run CPU-intensive handle_DATA in a thread pool executor
   ([#676](https://github.com/chatmail/relay/pull/676))
 

--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -14,6 +14,7 @@ smtp      inet  n       -       y       -       -       smtpd -v
 {%- else %}
 smtp      inet  n       -       y       -       -       smtpd 
 {%- endif %}
+  -o smtpd_tls_security_level=encrypt
   -o smtpd_proxy_filter=127.0.0.1:{{ config.filtermail_smtp_port_incoming }}
 submission inet n       -       y       -       5000    smtpd
   -o syslog_name=postfix/submission

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -143,6 +143,7 @@ def test_reject_missing_dkim(cmsetup, maildata, from_addr):
         "encrypted.eml", from_addr=from_addr, to_addr=recipient.addr
     ).as_string()
     conn = smtplib.SMTP(cmsetup.maildomain, 25, timeout=10)
+    conn.starttls()
 
     with conn as s:
         with pytest.raises(smtplib.SMTPDataError, match="No valid DKIM signature"):


### PR DESCRIPTION
We already require that outgoing connections
use STARTTLS so other servers need a valid TLS
certificate to accept messages from us.
It is then very unlikely that they cannot use TLS
to send messages to us.

Conversely, if they only can send messages to use without TLS, it likely does not have STARTLS on its port 25
and then we don't want to accept messages from them because we will likely not be able to reply.

Closes #681 