### PR TITLE
fixup of expiry-details after testing on real chatmail relay

### DIFF
--- a/chatmaild/src/chatmaild/expire.py
+++ b/chatmaild/src/chatmaild/expire.py
@@ -105,12 +105,17 @@ class Expiry:
 
         # all to-be-removed files are relative to the mailbox basedir
         os.chdir(mbox.basedir)
+        mboxname = os.path.basename(mbox.basedir)
+        if self.verbose:
+            print_info(f"checking for mailbox messages in: {mboxname}")
         self.all_files += len(mbox.messages)
         for message in mbox.messages:
             if message.mtime < cutoff_mails:
                 self.remove_file(message.relpath)
             elif message.size > 200000 and message.mtime < cutoff_large_mails:
-                self.remove_file(message.relpath)
+                # we only remove noticed large files (not unnoticed ones in new/)
+                if message.relpath.startswith("cur/"):
+                    self.remove_file(message.relpath)
             else:
                 continue
             changed = True

--- a/chatmaild/src/chatmaild/tests/test_expire.py
+++ b/chatmaild/src/chatmaild/tests/test_expire.py
@@ -123,6 +123,7 @@ def test_expiry_cli_old_files(capsys, example_config, mbox1):
             if fnmatch(line, f"removing*{path}"):
                 break
         else:
-            pytest.fail(f"failed to remove {path}\n{err}")
+            if path != "new/msg_old_large2":
+                pytest.fail(f"failed to remove {path}\n{err}")
 
     assert "shouldstay" not in err

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -161,9 +161,9 @@ def _install_remote_venv_with_chatmaild(config) -> None:
         systemd.service(
             name=f"Setup {basename}",
             service=basename,
-            running=True,
+            running=enabled,
             enabled=enabled,
-            restarted=True,
+            restarted=enabled,
             daemon_reload=True,
         )
 

--- a/cmdeploy/src/cmdeploy/service/chatmail-expire.service.f
+++ b/cmdeploy/src/cmdeploy/service/chatmail-expire.service.f
@@ -5,5 +5,5 @@ After=network.target
 [Service]
 Type=oneshot
 User=vmail
-ExecStart=/usr/local/lib/chatmaild/venv/bin/chatmail-expire /usr/local/lib/chatmaild/chatmail.ini --remove
+ExecStart=/usr/local/lib/chatmaild/venv/bin/chatmail-expire /usr/local/lib/chatmaild/chatmail.ini -v --remove
 


### PR DESCRIPTION

- don't remove large files already after 7 days if they are in the "new/" folder
- report which mailbox is being checked so that "journalctl -u chatmail-expire.service" provides sufficient output for checking
- don't trigger expiry or fsreport services during cmdeploy-run but run it from timer only
