### PR TITLE
acmetool: use ECDSA keys instead of RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- acmetool: use ECDSA keys instead of RSA
+  ([#689](https://github.com/chatmail/relay/pull/689))
+
 - Require TLS 1.2 for outgoing SMTP connections
   ([#685](https://github.com/chatmail/relay/pull/685))
 

--- a/cmdeploy/src/cmdeploy/acmetool/target.yaml.j2
+++ b/cmdeploy/src/cmdeploy/acmetool/target.yaml.j2
@@ -1,7 +1,8 @@
 request:
   provider: https://acme-v02.api.letsencrypt.org/directory
   key:
-    type: rsa
+    type: ecdsa
+    ecdsa-curve: nistp256
   challenge:
     webroot-paths:
     - /var/www/html/.well-known/acme-challenge


### PR DESCRIPTION
Replacement for https://github.com/chatmail/relay/pull/688

256-bit ECDSA keys are smaller than RSA-2048 and are roughly equivalent to RSA-3072. letsencrypt.org, google.com, github.com all use the same keys. See also https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html#why-we-issued-an-ecdsa-root-and-intermediates for comparison.