### PR TITLE
Update dovecot-core deb sha256 sums

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -338,9 +338,9 @@ def _install_dovecot_package(package: str, arch: str):
 
     match (package, arch):
         case ("core", "amd64"):
-            sha256 = "43f593332e22ac7701c62d58b575d2ca409e0f64857a2803be886c22860f5587"
+            sha256 = "dd060706f52a306fa863d874717210b9fe10536c824afe1790eec247ded5b27d"
         case ("core", "arm64"):
-            sha256 = "4d21eba1a83f51c100f08f2e49f0c9f8f52f721ebc34f75018e043306da993a7"
+            sha256 = "e7548e8a82929722e973629ecc40fcfa886894cef3db88f23535149e7f730dc9"
         case ("imapd", "amd64"):
             sha256 = "8d8dc6fc00bbb6cdb25d345844f41ce2f1c53f764b79a838eb2a03103eebfa86"
         case ("imapd", "arm64"):


### PR DESCRIPTION
Update dovecot-core package checksums.

Please, confirm before merging that the code is off rather than the delivery pipeline was compromised.

Current checksums for files I'm observing on download.delta.chat:
```
dd060706f52a306fa863d874717210b9fe10536c824afe1790eec247ded5b27d  dovecot-core_2.3.21%2Bdfsg1-3_amd64.deb
e7548e8a82929722e973629ecc40fcfa886894cef3db88f23535149e7f730dc9  dovecot-core_2.3.21%2Bdfsg1-3_arm64.deb
8d8dc6fc00bbb6cdb25d345844f41ce2f1c53f764b79a838eb2a03103eebfa86  dovecot-imapd_2.3.21%2Bdfsg1-3_amd64.deb
178fa877ddd5df9930e8308b518f4b07df10e759050725f8217a0c1fb3fd707f  dovecot-imapd_2.3.21%2Bdfsg1-3_arm64.deb
2f69ba5e35363de50962d42cccbfe4ed8495265044e244007d7ccddad77513ab  dovecot-lmtpd_2.3.21%2Bdfsg1-3_amd64.deb
89f52fb36524f5877a177dff4a713ba771fd3f91f22ed0af7238d495e143b38f  dovecot-lmtpd_2.3.21%2Bdfsg1-3_arm64.deb
```

Only dovecot-core checksums are off for both architectures.