### PR TITLE
Remove smtp_tls_security_level exception for nauta.cu

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -25,7 +25,6 @@ smtp_tls_security_level=verify
 # <https://www.postfix.org/postconf.5.html#smtp_tls_servername>
 smtp_tls_servername = hostname
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
-smtp_tls_policy_maps = inline:{nauta.cu=may}
 smtp_tls_protocols = >=TLSv1.2
 smtpd_tls_protocols = >=TLSv1.2
 


### PR DESCRIPTION
nauta.cu MX servers don't support STARTTLS
and we have maintained this exception to allow delivery to nauta.cu. Since nauta.cu has blocked largest chatmail relay instances, we can remove this exception.
Even if it works today for some chatmail servers,
they will likely be blocked once the number of users grows. Even now users from nauta.cu cannot practically participate in groups.