### PR TITLE
Remove acmetool cronjob

### DIFF
--- a/cmdeploy/src/cmdeploy/acmetool/__init__.py
+++ b/cmdeploy/src/cmdeploy/acmetool/__init__.py
@@ -10,12 +10,9 @@ def deploy_acmetool(email="", domains=[]):
         packages=["acmetool"],
     )
 
-    files.put(
-        src=importlib.resources.files(__package__).joinpath("acmetool.cron").open("rb"),
-        dest="/etc/cron.d/acmetool",
-        user="root",
-        group="root",
-        mode="644",
+    files.file(
+        path="/etc/cron.d/acmetool",
+        present=False,
     )
 
     files.put(

--- a/cmdeploy/src/cmdeploy/acmetool/acmetool.cron
+++ b/cmdeploy/src/cmdeploy/acmetool/acmetool.cron
@@ -1,4 +1,0 @@
-SHELL=/bin/sh
-PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-MAILTO=root
-20 16 * * * root /usr/bin/acmetool --batch reconcile && systemctl reload dovecot && systemctl reload postfix && systemctl reload nginx


### PR DESCRIPTION
acmetool is always running in redirector mode and has a hook that restarts or reload services, there is no need to do the same manually.