### PR TITLE
Fix quotes in page-layout.html

### DIFF
--- a/www/src/page-layout.html
+++ b/www/src/page-layout.html
@@ -9,7 +9,7 @@
     <title>{{ config.mail_domain }} {{ pagename }}</title>
     <link rel="stylesheet" href="./main.css">
     <link rel="icon" href="/logo.svg">
-    <link rel=”mask-icon” href=”/logo.svg” color=”#000000">
+    <link rel="mask-icon" href="/logo.svg" color="#000000">
 </head>
 <body>
 


### PR DESCRIPTION
I'm guessing that web browsers are flexible enough, but my text editor noticed. :sweat_smile: 