### PR TITLE
turnserver: Strip newline from response.

### DIFF
--- a/chatmaild/src/chatmaild/turnserver.py
+++ b/chatmaild/src/chatmaild/turnserver.py
@@ -6,4 +6,4 @@ def turn_credentials() -> str:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client_socket:
         client_socket.connect("/run/chatmail-turn/turn.socket")
         with client_socket.makefile("rb") as file:
-            return file.readline().decode("utf-8")
+            return file.readline().decode("utf-8").strip()


### PR DESCRIPTION
I noticed warnings like these in my dovecot logs:

```
Nov 01 16:22:22 … dovecot[…]: imap(…)<…><…>: Error: dict(proxy): conn unix:/run/chatmail-metadata/metadata.socket (pid=…,uid=…): Received reply without pending commands:
```

Looking at https://github.com/chatmail/chatmail-turn/blob/main/src/main.rs#L43 it seems the turn server writes a newline-terminated response, but that newline was never stripped off and passed as-is to the dict client via https://github.com/chatmail/relay/blob/main/chatmaild/src/chatmaild/metadata.py#L106, which confuses dovecot.