### PR TITLE
CI: fix test methods for deltachat 2.23.0

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/benchmark.py
+++ b/cmdeploy/src/cmdeploy/tests/online/benchmark.py
@@ -37,7 +37,7 @@ class TestDC:
 
     def test_ping_pong(self, benchmark, cmfactory):
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_protected_chat(ac1, ac2)
+        chat = cmfactory.get_accepted_chat(ac1, ac2)
 
         def dc_ping_pong():
             chat.send_text("ping")
@@ -49,7 +49,7 @@ class TestDC:
 
     def test_send_10_receive_10(self, benchmark, cmfactory, lp):
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_protected_chat(ac1, ac2)
+        chat = cmfactory.get_accepted_chat(ac1, ac2)
 
         def dc_send_10_receive_10():
             for i in range(10):

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -56,7 +56,7 @@ class TestEndToEndDeltaChat:
         """Test that a DC account can send a message to a second DC account
         on the same chat-mail instance."""
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_protected_chat(ac1, ac2)
+        chat = cmfactory.get_accepted_chat(ac1, ac2)
         chat.send_text("message0")
 
         lp.sec("wait for ac2 to receive message")
@@ -70,7 +70,7 @@ class TestEndToEndDeltaChat:
         before quota is exceeded, and thus depends on the speed of the upload.
         """
         ac1, ac2 = cmfactory.get_online_accounts(2)
-        chat = cmfactory.get_protected_chat(ac1, ac2)
+        chat = cmfactory.get_accepted_chat(ac1, ac2)
 
         user = ac2.get_config("configured_addr")
 
@@ -153,7 +153,7 @@ def test_hide_senders_ip_address(cmfactory):
     assert ipaddress.ip_address(public_ip)
 
     user1, user2 = cmfactory.get_online_accounts(2)
-    chat = cmfactory.get_protected_chat(user1, user2)
+    chat = cmfactory.get_accepted_chat(user1, user2)
 
     chat.send_text("testing submission header cleanup")
     user2._evtracker.wait_next_incoming_message()


### PR DESCRIPTION
With deltachat 2.23.0, the tests started failing.

Unfortunately it seems that we can't really pin a version, as deltachat is not installed as a dependency, but in `cmdeploy.py` - with the current way of checking for the package, people who have legacy deltachat installed will get test failures, while `cmdeploy test` will not update automatically. But a `venv/bin/pip install -U deltachat` should solve it for them.