### PR TITLE
fix and update mermaid overview graph

### DIFF
--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -171,7 +171,7 @@ Chatmail relay dependency diagram
         chatmail-expire-daily --- maildir;
         chatmail-fsreport-daily --- maildir;
         chatmail-metadata --- iroh-relay;
-        chatmail-metadata --- |encrypted device token| notification-proxy;
+        chatmail-metadata --- |encrypted device token| notifications.delta.chat;
         certs-nginx --> postfix;
         certs-nginx --> dovecot;
         style certs fill:#ff6;


### PR DESCRIPTION
- remove "cmdeploy" from relay diagram 
- replace cron with systemd and add edges
- be more detailed about filtermail-incoming versus outgoing 
- color internet reachable services red, color all filesystem-locations yellow
- fix postfix to use dovecot for SASL, instead of the wrong depicted direct use of doveauth
- add lastlogin component 
- add notification proxy 

