### PR TITLE
echobot: require dovecot to be running

### DIFF
--- a/cmdeploy/src/cmdeploy/service/echobot.service.f
+++ b/cmdeploy/src/cmdeploy/service/echobot.service.f
@@ -1,5 +1,6 @@
 [Unit]
 Description=Chatmail echo bot for testing it works
+Requires=dovecot.service
 
 [Service]
 ExecStart={execpath} {config_path}


### PR DESCRIPTION
The changes in https://github.com/chatmail/relay/pull/741/files#r2564775943 re-introduce #641. This might help - it worked for me on docker.testrun.org.