### PR TITLE
echobot: print invite link without SSH if deployed locally/with docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Organized cmdeploy into install, configure, and activate stages
   ([#695](https://github.com/chatmail/relay/pull/695))
 
+- echobot: print invite-link also if it's deployed locally
+  ([#751](https://github.com/chatmail/relay/pull/751))
+
 - docs: move readme.md docs to sphinx documentation rendered at https://chatmail.at/doc/relay 
   ([#711](https://github.com/chatmail/relay/pull/711))
 


### PR DESCRIPTION
superseding #741 - it would still be nice to wait until the file is created for the SSH code path, but then again it takes longer to establish, so the chance is higher that it just works.