### PR TITLE
opendkim: report DKIM error code in SMTP response

### DIFF
--- a/cmdeploy/src/cmdeploy/opendkim/final.lua
+++ b/cmdeploy/src/cmdeploy/opendkim/final.lua
@@ -10,7 +10,7 @@ if nsigs == nil then
 end
 
 local valid = false
-local sigerrors = ""
+local error_msg = "No valid DKIM signature found."
 for i = 1, nsigs do
 	sig = odkim.get_sighandle(ctx, i - 1)
 	sigres = odkim.sig_result(sig)
@@ -23,7 +23,7 @@ for i = 1, nsigs do
 	if sigres == 0 then
 		valid = true
     else
-        sigerrors = sigerrors .. " " .. tostring(sigres)
+        error_msg = "DKIM signature is invalid, error code " .. tostring(sigres) .. ", search https://github.com/trusteddomainproject/OpenDKIM/blob/master/libopendkim/dkim.h#L108"
 	end
 end
 
@@ -34,7 +34,7 @@ if valid then
 		odkim.del_header(ctx, "DKIM-Signature", i)
 	end
 else
-	odkim.set_reply(ctx, "554", "5.7.1", "No valid DKIM signature found. Search https://github.com/trusteddomainproject/OpenDKIM/blob/master/libopendkim/dkim.h#L108 for " .. sigerrors)
+	odkim.set_reply(ctx, "554", "5.7.1", error_msg)
 	odkim.set_result(ctx, SMFIS_REJECT)
 end
 


### PR DESCRIPTION
This was very useful in debugging #762, does anything speak against making the rejection reason transparent?