### PR TITLE
decoms development instance notice

### DIFF
--- a/www/src/index.md
+++ b/www/src/index.md
@@ -23,7 +23,3 @@ you can also **scan this QR code** with Delta Chat:
 🐣 **Choose** your Avatar and Name
 
 💬 **Start** chatting with any Delta Chat contacts using [QR invite codes](https://delta.chat/en/help#howtoe2ee)
-
-{% if config.mail_domain != "nine.testrun.org" %}
-<div class="experimental">Note: this is only a temporary development chatmail service</div>
-{% endif %}


### PR DESCRIPTION
pr overview:
- in chats we discussed having operators remove the development instance notice
- some operators ignore the development instance banner even after their relay is stable
- this pr removes the notice, we can discuss pros/cons but i feel it doesn't serve a purpose