### PR TITLE
Make filtermail use normal 127.0.0.1 as the source address

### DIFF
--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -312,7 +312,7 @@ class IncomingBeforeQueueHandler:
         client = SMTPClient(
             "localhost",
             self.config.postfix_reinject_port_incoming,
-            source_address=("127.0.0.2", 0),
+            source_address=("127.0.0.1", 0),
         )
         client.sendmail(
             envelope.mail_from, envelope.rcpt_tos, envelope.original_content


### PR DESCRIPTION
On some OSes in you can use any address in the 127.0.0.0/8 range and it will work fine, but FreeBSD won't allow it.