### PR TITLE
streamline migration guide wording, provide titled steps 

### DIFF
--- a/doc/source/migrate.rst
+++ b/doc/source/migrate.rst
@@ -54,7 +54,7 @@ in this case, just run ``ssh-keygen -R "mail.example.org"`` as recommended.
 
    ::
 
-       cmdeploy run --disable-mail --ssh-host $OLD_IP4
+       scripts/cmdeploy run --disable-mail --ssh-host $OLD_IP4
 
 
 4. **Final synchronization of TLS/DKIM secrets, mail queues and mailboxes.**


### PR DESCRIPTION
This started from #780 but grew into a larger refactoring.  It tries to be very short, and provide titles
to the various steps, so it's clearer what happens. Also, operators might be executing the steps while being in an emergency (discs failing). 

closes #780 