### PR TITLE
fix: properly make sure that postfix gets restarted on failure

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/deployer.py
+++ b/cmdeploy/src/cmdeploy/postfix/deployer.py
@@ -65,7 +65,7 @@ class PostfixDeployer(Deployer):
         restart_conf = files.put(
             name="postfix: restart automatically on failure",
             src=get_resource("service/10_restart.conf"),
-            dest="/etc/systemd/system/postfix.service.d/10_restart.conf",
+            dest="/etc/systemd/system/postfix@.service.d/10_restart.conf",
         )
         self.daemon_reload = restart_conf.changed
         self.need_restart = need_restart


### PR DESCRIPTION
found this fix in omidz4t fork 
 https://github.com/chatmail/relay/compare/main...omidz4t:relay-ir:main