### PR TITLE
expire.py: use absolute path to maildirsize

### DIFF
--- a/chatmaild/src/chatmaild/expire.py
+++ b/chatmaild/src/chatmaild/expire.py
@@ -144,7 +144,7 @@ class Expiry:
                 continue
             changed = True
         if changed:
-            self.remove_file("maildirsize")
+            self.remove_file(f"{mbox.basedir}/maildirsize")
 
     def get_summary(self):
         return (


### PR DESCRIPTION
It appears we're not actually deleting the maildirsize file because we're not providing an absolute path?