### PR TITLE
mtail: explicitly read from /dev/stdin

### DIFF
--- a/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
+++ b/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
@@ -3,7 +3,7 @@ Description=mtail
 
 [Service]
 Type=simple
-ExecStart=/bin/sh -c "journalctl -f -o short-iso -n 0 | /usr/local/bin/mtail --address={{ address }} --port={{ port }} --progs /etc/mtail --logtostderr --logs -"
+ExecStart=/bin/sh -c "journalctl -f -o short-iso -n 0 | /usr/local/bin/mtail --address={{ address }} --port={{ port }} --progs /etc/mtail --logtostderr --logs /dev/stdin"
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
I wish I could understand why this was happening, but even though my deployment with my Chatmail cookbook produced a 100% identical ExecStart command, the mtail process was trying to read a file named /- which did not exist.

This is a harmless change and should ensure nobody else runs into this mysterious edge case.