### PR TITLE
Dovecot: disable appending the Received header

### DIFF
--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -168,6 +168,8 @@ service lmtp {
   }
 }
 
+lmtp_add_received_header = no
+
 service auth {
   unix_listener /var/spool/postfix/private/auth {
     mode = 0660


### PR DESCRIPTION
This suppresses a Received header only applied during LMTP processing and includes a timestamp.

#814 