### PR TITLE
Aggressive LMTP header cleanup

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
+++ b/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
@@ -2,12 +2,16 @@
 # that must be retained for functionality and compatibility reasons 
 /^From:/            DUNNO
 /^Message-Id:/      DUNNO
-/^Chat-Is-Post-Message:/      DUNNO
+/^Chat-/            DUNNO
 /^Content-Type:/    DUNNO
 
 # For receiving clear-text messages (still supported in May 2026)
 /^Subject:/         DUNNO
 /^Date:/            DUNNO
+/^To:/              DUNNO
+/^CC:/              DUNNO
+/^References:/      DUNNO
+/^In-Reply-To:/     DUNNO
 
 # Senders might support Autocrypt 1 but not RFC9788 (Header Protection) 
 /^Autocrypt:/            DUNNO

--- a/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
+++ b/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
@@ -1,7 +1,23 @@
+# List of headers for incoming messages 
+# that must be retained for functionality and compatibility reasons 
 /^From:/            DUNNO
 /^Message-Id:/      DUNNO
 /^Chat-Is-Post-Message:/      DUNNO
 /^Content-Type:/    DUNNO
+
+# For receiving clear-text messages (still supported in May 2026)
 /^Subject:/         DUNNO
 /^Date:/            DUNNO
+
+# Senders might support Autocrypt 1 but not RFC9788 (Header Protection) 
+/^Autocrypt:/            DUNNO
+
+# SecureJoin V2 protocol headers (for backward compatibility) 
+/^Secure-Join:/             DUNNO
+/^Secure-Join-Invitenumber:/ DUNNO
+/^Secure-Join-Auth:/        DUNNO
+/^Secure-Join-Fingerprint:/ DUNNO
+/^Secure-Join-Group:/       DUNNO
+
+# Ignore all other headers
 /.*/                IGNORE

--- a/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
+++ b/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
@@ -1,3 +1,7 @@
-/^DKIM-Signature:/            IGNORE
-/^Authentication-Results:/            IGNORE
-/^Received:/            IGNORE
+/^From:/            DUNNO
+/^Message-Id:/      DUNNO
+/^Chat-Is-Post-Message:/      DUNNO
+/^Content-Type:/    DUNNO
+/^Subject:/         DUNNO
+/^Date:/            DUNNO
+/.*/                IGNORE

--- a/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
+++ b/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
@@ -14,14 +14,10 @@
 /^In-Reply-To:/     DUNNO
 
 # Senders might support Autocrypt 1 but not RFC9788 (Header Protection) 
-/^Autocrypt:/            DUNNO
+/^Autocrypt:/       DUNNO
 
 # SecureJoin V2 protocol headers (for backward compatibility) 
-/^Secure-Join:/             DUNNO
-/^Secure-Join-Invitenumber:/ DUNNO
-/^Secure-Join-Auth:/        DUNNO
-/^Secure-Join-Fingerprint:/ DUNNO
-/^Secure-Join-Group:/       DUNNO
+/^Secure-Join/      DUNNO
 
 # Ignore all other headers
 /.*/                IGNORE


### PR DESCRIPTION
This will remove all headers possible during LMTP delivery.

From header: required or clients do not process the message correctly

Message-Id header: required for clients to know which messages have been downloaded