### PR TITLE
test: fix flaky test_exceed_rate_limit

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -190,22 +190,17 @@ def test_exceed_rate_limit(cmsetup, gencreds, maildata, chatmail_config):
         "encrypted.eml", from_addr=user1.addr, to_addr=user2.addr
     ).as_string()
 
-    timestamps = []
-    i = 0
-    while len(timestamps) <= chatmail_config.max_user_send_per_minute * 1.7:
+    for i in range(chatmail_config.max_user_send_per_minute * 3):
         print("Sending mail", str(i))
-        i += 1
         try:
             user1.smtp.sendmail(user1.addr, [user2.addr], mail)
-            timestamps.append(time.time())
         except smtplib.SMTPException as e:
-            if len(timestamps) < chatmail_config.max_user_send_per_minute:
+            if i < chatmail_config.max_user_send_per_minute:
                 pytest.fail(f"rate limit was exceeded too early with msg {i}")
             outcome = e.recipients[user2.addr]
             assert outcome[0] == 450
             assert b"4.7.1: Too much mail from" in outcome[1]
             return
-        timestamps[:] = [ts for ts in timestamps if ts >= (time.time() - 60)]
     pytest.fail("Rate limit was not exceeded")
 
 


### PR DESCRIPTION
filtermail rate limiter is using leaky bucket
algorithm (GCRA).
Exceeting the limit requires sending
at least max_user_send_per_minute
messages to exhaust allowed burst,
and then sending messages faster
than the leak rate.
As we don't know how fast is the network
between the server and test runner,
try to send 3 times max_user_send_per_minute
messages to ensure the test does not
fail randomly.

Closes #821 