### PR TITLE
fix: remediates issue with improper concat on resolver injection

### DIFF
--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -550,22 +550,11 @@ def deploy_chatmail(config_path: Path, disable_mail: bool, website_only: bool) -
         return
 
     if host.get_fact(Port, port=53) != "unbound":
-        server.shell(
-            name="Ensure resolv.conf ends with newline",
-            commands=[
-                "python3 - <<'PY'\n"
-                "from pathlib import Path\n"
-                "path = Path('/etc/resolv.conf')\n"
-                "data = path.read_bytes() if path.exists() else b''\n"
-                "if data and not data.endswith(b'\\n'):\n"
-                "    path.write_bytes(data + b'\\n')\n"
-                "PY"
-            ],
-        )
         files.line(
             name="Add 9.9.9.9 to resolv.conf",
             path="/etc/resolv.conf",
-            line="nameserver 9.9.9.9",
+            # Guard against resolv.conf missing a trailing newline (SolusVM bug).
+            line="\nnameserver 9.9.9.9",
         )
 
     port_services = [


### PR DESCRIPTION
pr overview:
- addresses issue #833 
- in some hosting providers when we inject `9.9.9.9` from `cmdeploy/src/cmdeploy/deployers.py` the injection of `9.9.9.9` can have an improper concat which causes name resolution to fail and the deploy to bail out
- this branch has been tested on racknerd and cloudfanatic where i was experiencing the problem
- full end to end smoke test on clean and existing relays demonstrates the behavior is corrected

----
before (current main branch)

````
# Generated by SolusVM
nameserver 8.8.8.8
nameserver 8.8.4.4nameserver 9.9.9.9
````

after (373/fix-dns-resolver-injection branch)

````
# Generated by SolusVM
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 9.9.9.9
````
