### PR TITLE
fix(doc): /source/related.rst madmail repo link

### DIFF
--- a/doc/source/related.rst
+++ b/doc/source/related.rst
@@ -14,7 +14,7 @@ We know of three work-in-progress alternative implementation efforts:
    it to support all of the features and configuration settings required
    to operate as a chatmail relay.
 
--  `Madmail <https://github.com/omidz4t/madmail>`_: an
+-  `Madmail <https://github.com/themadorg/madmail>`_: an
    experimental fork of Maddy Mail Server <https://maddy.email/>`_ optimized
    for chatmail deployments.  It provides a single binary solution
    for running a chatmail relay.


### PR DESCRIPTION
Update madmail link to new repo (failed linkcheck during CI doc rebuild).