### PR TITLE
feat: reconfigure acmetool from redirector to proxy mode

### DIFF
--- a/cmdeploy/src/cmdeploy/acmetool/acmetool-redirector.service
+++ b/cmdeploy/src/cmdeploy/acmetool/acmetool-redirector.service
@@ -3,7 +3,7 @@ Description=acmetool HTTP redirector
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/acmetool redirector --service.uid=daemon
+ExecStart=/usr/bin/acmetool redirector --service.uid=daemon --bind=127.0.0.1:402
 Restart=always
 RestartSec=30
 

--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -572,9 +572,13 @@ def deploy_chatmail(config_path: Path, disable_mail: bool, website_only: bool) -
         ("unbound", 53),
     ]
     if config.tls_cert_mode == "acme":
-        port_services.append(("acmetool", 80))
+        port_services.append(("acmetool", 402))
     port_services += [
         (["imap-login", "dovecot"], 143),
+        # acmetool previously listened on port 80,
+        # so don't complain during upgrade that moved it to port 402
+        # and gave the port to nginx.
+        (["acmetool", "nginx"], 80),
         ("nginx", 443),
         (["master", "smtpd"], 465),
         (["master", "smtpd"], 587),

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -145,4 +145,25 @@ http {
 		return 301 $scheme://{{ config.mail_domain }}$request_uri;
 		access_log syslog:server=unix:/dev/log,facility=local7;
 	}
+
+	server {
+		listen 80;
+		{% if not disable_ipv6 %}
+		listen [::]:80;
+		{% endif %}
+
+		{% if config.tls_cert_mode == "acme" %}
+		location /.well-known/acme-challenge/ {
+			proxy_pass http://acmetool;
+		}
+		{% endif %}
+
+		return 301 https://$host$request_uri;
+	}
+
+	{% if config.tls_cert_mode == "acme" %}
+	upstream acmetool {
+		server 127.0.0.1:402;
+	}
+	{% endif %}
 }


### PR DESCRIPTION
This elimitates the problem of acmetool failing
to start when nginx is installed already and uses port 80.

This also makes nginx redirect HTTP requests to HTTPS for setups that don't have acmetool.

Closes #809