### PR TITLE
fix: restart dovecot after package replacement (rebase, test condense)

### DIFF
--- a/cmdeploy/src/cmdeploy/dovecot/deployer.py
+++ b/cmdeploy/src/cmdeploy/dovecot/deployer.py
@@ -15,7 +15,8 @@ from cmdeploy.basedeploy import (
     get_resource,
 )
 
-DOVECOT_VERSION = "2.3.21+dfsg1-3"
+DOVECOT_ARCHIVE_VERSION = "2.3.21+dfsg1-3"
+DOVECOT_PACKAGE_VERSION = f"1:{DOVECOT_ARCHIVE_VERSION}"
 
 DOVECOT_SHA256 = {
     ("core", "amd64"): "dd060706f52a306fa863d874717210b9fe10536c824afe1790eec247ded5b27d",
@@ -40,11 +41,14 @@ class DovecotDeployer(Deployer):
         with blocked_service_startup():
             debs = []
             for pkg in ("core", "imapd", "lmtpd"):
-                deb = _download_dovecot_package(pkg, arch)
+                deb, changed = _download_dovecot_package(pkg, arch)
+                self.need_restart |= changed
                 if deb:
                     debs.append(deb)
             if debs:
                 deb_list = " ".join(debs)
+                # First dpkg may fail on missing dependencies (stderr suppressed);
+                # apt-get --fix-broken pulls them in, then dpkg retries cleanly.
                 server.shell(
                     name="Install dovecot packages",
                     commands=[
@@ -53,6 +57,7 @@ class DovecotDeployer(Deployer):
                         f"dpkg --force-confdef --force-confold -i {deb_list}",
                     ],
                 )
+                self.need_restart = True
         files.put(
             name="Pin dovecot packages to block Debian dist-upgrades",
             src=io.StringIO(
@@ -68,7 +73,8 @@ class DovecotDeployer(Deployer):
 
     def configure(self):
         configure_remote_units(self.config.mail_domain, self.units)
-        self.need_restart, self.daemon_reload = _configure_dovecot(self.config)
+        config_restart, self.daemon_reload = _configure_dovecot(self.config)
+        self.need_restart |= config_restart
 
     def activate(self):
         activate_remote_units(self.units)
@@ -97,22 +103,22 @@ def _pick_url(primary, fallback):
         return fallback
 
 
-def _download_dovecot_package(package: str, arch: str):
-    """Download a dovecot .deb if needed, return its path (or None)."""
+def _download_dovecot_package(package: str, arch: str) -> tuple[str | None, bool]:
+    """Download a dovecot .deb if needed, return (path, changed)."""
     arch = "amd64" if arch == "x86_64" else arch
     arch = "arm64" if arch == "aarch64" else arch
 
     pkg_name = f"dovecot-{package}"
     sha256 = DOVECOT_SHA256.get((package, arch))
     if sha256 is None:
-        apt.packages(packages=[pkg_name])
-        return None
+        op = apt.packages(packages=[pkg_name])
+        return None, bool(getattr(op, "changed", False))
 
     installed_versions = host.get_fact(DebPackages).get(pkg_name, [])
-    if DOVECOT_VERSION in installed_versions:
-        return None
+    if DOVECOT_PACKAGE_VERSION in installed_versions:
+        return None, False
 
-    url_version = DOVECOT_VERSION.replace("+", "%2B")
+    url_version = DOVECOT_ARCHIVE_VERSION.replace("+", "%2B")
     deb_base = f"{pkg_name}_{url_version}_{arch}.deb"
     primary_url = f"https://download.delta.chat/dovecot/{deb_base}"
     fallback_url = f"https://github.com/chatmail/dovecot/releases/download/upstream%2F{url_version}/{deb_base}"
@@ -127,7 +133,7 @@ def _download_dovecot_package(package: str, arch: str):
         cache_time=60 * 60 * 24 * 365 * 10,  # never redownload the package
     )
 
-    return deb_filename
+    return deb_filename, True
 
 
 def _can_set_inotify_limits() -> bool:

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -71,6 +71,44 @@ class TestSSHExecutor:
         assert (now - since_date).total_seconds() < 60 * 60 * 51
 
 
+def test_dovecot_main_process_matches_installed_binary(sshdomain):
+    sshexec = get_sshexec(sshdomain)
+    main_pid = int(
+        sshexec(
+            call=remote.rshell.shell,
+            kwargs=dict(
+                command="timeout 10 systemctl show -p MainPID --value dovecot.service"
+            ),
+        ).strip()
+    )
+    assert main_pid != 0, "dovecot.service MainPID is 0 -- service not running?"
+
+    exe = sshexec(
+        call=remote.rshell.shell,
+        kwargs=dict(command=f"timeout 10 readlink /proc/{main_pid}/exe"),
+    ).strip()
+    status_text = sshexec(
+        call=remote.rshell.shell,
+        kwargs=dict(
+            command="timeout 10 systemctl show -p StatusText --value dovecot.service"
+        ),
+    ).strip()
+    installed_version = sshexec(
+        call=remote.rshell.shell, kwargs=dict(command="timeout 10 dovecot --version")
+    ).strip()
+
+    assert not exe.endswith("(deleted)"), (
+        f"running dovecot binary was deleted (stale after upgrade): {exe}"
+    )
+    expected_status_text = f"v{installed_version}"
+    assert status_text == expected_status_text or status_text.startswith(
+        f"{expected_status_text} "
+    ), (
+        f"dovecot status version mismatch: "
+        f"StatusText={status_text!r}, installed={installed_version!r}"
+    )
+
+
 def test_timezone_env(remote):
     for line in remote.iter_output("env"):
         print(line)

--- a/cmdeploy/src/cmdeploy/tests/test_dovecot_deployer.py
+++ b/cmdeploy/src/cmdeploy/tests/test_dovecot_deployer.py
@@ -1,0 +1,238 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from cmdeploy.dovecot import deployer as dovecot_deployer
+from pyinfra.facts.deb import DebPackages
+
+
+def make_host(*fact_pairs):
+    """Build a mock host; get_fact(cls) dispatches to the provided facts mapping.
+
+    Args:
+        *fact_pairs: tuples of (fact_class, fact_value) to register
+
+    Returns:
+        SimpleNamespace with get_fact that raises a clear error if an
+        unexpected fact type is requested.
+    """
+    facts = dict(fact_pairs)
+
+    def get_fact(cls):
+        if cls not in facts:
+            registered = ", ".join(c.__name__ for c in facts)
+            raise LookupError(
+                f"unexpected get_fact({cls.__name__}); "
+                f"only registered: {registered}"
+            )
+        return facts[cls]
+
+    return SimpleNamespace(get_fact=get_fact)
+
+
+@pytest.fixture
+def deployer():
+    return dovecot_deployer.DovecotDeployer(
+        SimpleNamespace(mail_domain="chat.example.org"),
+        disable_mail=False,
+    )
+
+
+@pytest.fixture
+def patch_blocked(monkeypatch):
+    monkeypatch.setattr(dovecot_deployer, "blocked_service_startup", nullcontext)
+
+
+@pytest.fixture
+def mock_files_put(monkeypatch):
+    monkeypatch.setattr(
+        dovecot_deployer.files,
+        "put",
+        lambda **kwargs: SimpleNamespace(changed=False),
+    )
+
+
+@pytest.fixture
+def track_shell(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        dovecot_deployer.server,
+        "shell",
+        lambda **kwargs: calls.append(kwargs) or SimpleNamespace(changed=False),
+    )
+    return calls
+
+
+def test_download_dovecot_package_skips_epoch_matched_install(monkeypatch):
+    epoch_version = dovecot_deployer.DOVECOT_PACKAGE_VERSION
+    downloads = []
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "host",
+        make_host((DebPackages, {"dovecot-core": [epoch_version]})),
+    )
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "_pick_url",
+        lambda primary, fallback: primary,
+    )
+    monkeypatch.setattr(
+        dovecot_deployer.files,
+        "download",
+        lambda **kwargs: downloads.append(kwargs),
+    )
+
+    deb, changed = dovecot_deployer._download_dovecot_package("core", "amd64")
+
+    assert deb is None, f"expected no deb path when version matches, got {deb!r}"
+    assert changed is False, "should not flag changed when version already installed"
+    assert downloads == [], "should not download when version already installed"
+
+
+def test_download_dovecot_package_uses_archive_version_for_url_and_filename(
+    monkeypatch,
+):
+    downloads = []
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "host",
+        make_host((DebPackages, {})),
+    )
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "_pick_url",
+        lambda primary, fallback: primary,
+    )
+    monkeypatch.setattr(
+        dovecot_deployer.files,
+        "download",
+        lambda **kwargs: downloads.append(kwargs),
+    )
+
+    deb, changed = dovecot_deployer._download_dovecot_package("core", "amd64")
+
+    archive_version = dovecot_deployer.DOVECOT_ARCHIVE_VERSION.replace("+", "%2B")
+    expected_deb = f"/root/dovecot-core_{archive_version}_amd64.deb"
+
+    # Verify the returned path uses archive version, not package version (with epoch)
+    assert changed is True, "should flag changed when package not yet installed"
+    assert deb == expected_deb, f"deb path mismatch: {deb!r} != {expected_deb!r}"
+    assert dovecot_deployer.DOVECOT_PACKAGE_VERSION not in deb, (
+        f"deb path should use archive version (no epoch), got {deb!r}"
+    )
+    assert len(downloads) == 1, "files.download should be called exactly once"
+
+
+def test_install_skips_dpkg_path_when_epoch_matched_packages_present(
+    deployer, patch_blocked, mock_files_put, track_shell, monkeypatch
+):
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "host",
+        make_host(
+            (
+                dovecot_deployer.DebPackages,
+                {
+                    "dovecot-core": [dovecot_deployer.DOVECOT_PACKAGE_VERSION],
+                    "dovecot-imapd": [dovecot_deployer.DOVECOT_PACKAGE_VERSION],
+                    "dovecot-lmtpd": [dovecot_deployer.DOVECOT_PACKAGE_VERSION],
+                },
+            ),
+            (dovecot_deployer.Arch, "x86_64"),
+        ),
+    )
+    downloads = []
+    monkeypatch.setattr(
+        dovecot_deployer.files,
+        "download",
+        lambda **kwargs: downloads.append(kwargs),
+    )
+
+    deployer.install()
+
+    assert downloads == [], "should not download when all packages epoch-matched"
+    assert track_shell == [], "should not run dpkg when all packages epoch-matched"
+    assert deployer.need_restart is False, (
+        "need_restart should be False when nothing changed"
+    )
+
+
+def test_install_unsupported_arch_falls_back_to_apt(
+    deployer, patch_blocked, mock_files_put, track_shell, monkeypatch
+):
+    # For unsupported architectures, all fact lookups return the arch string.
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "host",
+        SimpleNamespace(get_fact=lambda cls: "riscv64"),
+    )
+    apt_calls = []
+
+    # Mirrors apt.packages() return value: OperationMeta with .changed property.
+    # Only lmtpd triggers a change to verify |= accumulation of changed flags.
+    def fake_apt(**kwargs):
+        apt_calls.append(kwargs)
+        changed = "lmtpd" in kwargs["packages"][0]
+        return SimpleNamespace(changed=changed)
+
+    monkeypatch.setattr(dovecot_deployer.apt, "packages", fake_apt)
+
+    deployer.install()
+
+    actual_pkgs = [c["packages"] for c in apt_calls]
+    assert actual_pkgs == [["dovecot-core"], ["dovecot-imapd"], ["dovecot-lmtpd"]], (
+        f"expected apt install of core/imapd/lmtpd, got {actual_pkgs}"
+    )
+    assert track_shell == [], "should not run dpkg for unsupported arch"
+    assert deployer.need_restart is True, (
+        "need_restart should be True when apt installed a package"
+    )
+
+
+def test_install_runs_dpkg_when_packages_need_download(
+    deployer, patch_blocked, mock_files_put, track_shell, monkeypatch
+):
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "host",
+        make_host(
+            (dovecot_deployer.DebPackages, {}),
+            (dovecot_deployer.Arch, "x86_64"),
+        ),
+    )
+    monkeypatch.setattr(
+        dovecot_deployer,
+        "_pick_url",
+        lambda primary, fallback: primary,
+    )
+    monkeypatch.setattr(
+        dovecot_deployer.files,
+        "download",
+        lambda **kwargs: SimpleNamespace(changed=True),
+    )
+
+    deployer.install()
+
+    assert len(track_shell) == 1, (
+        f"expected one server.shell() call for dpkg install, got {len(track_shell)}"
+    )
+    cmds = track_shell[0]["commands"]
+    assert len(cmds) == 3, f"expected 3 dpkg/apt commands, got: {cmds}"
+    assert cmds[0].startswith("dpkg --force-confdef --force-confold -i ")
+    assert "apt-get -y --fix-broken install" in cmds[1]
+    assert cmds[2].startswith("dpkg --force-confdef --force-confold -i ")
+    assert deployer.need_restart is True, (
+        "need_restart should be True after dpkg install"
+    )
+
+
+def test_pick_url_falls_back_on_primary_error(monkeypatch):
+    def raise_error(req, timeout):
+        raise OSError("connection timeout")
+
+    monkeypatch.setattr(dovecot_deployer.urllib.request, "urlopen", raise_error)
+    result = dovecot_deployer._pick_url("http://primary", "http://fallback")
+    assert result == "http://fallback", (
+        f"should fall back when primary fails, got {result!r}"
+    )


### PR DESCRIPTION
Original:

- track Dovecot package replacement separately from config-driven restart logic in cmdeploy
- explicitly restart Dovecot after package changes even when policy-rc.d blocks package-triggered restarts
- add unit coverage for package-change restart behavior and an online regression for stale deleted Dovecot binaries

This branch:
-  fixed my remark (overly specific assert)
- second commit condensed the tests a bit

Supercedes / Replaces / Closes #904 