### PR TITLE
fix(cmdeploy): Set permissions on dovecot pin prefs

### DIFF
--- a/cmdeploy/src/cmdeploy/dovecot/deployer.py
+++ b/cmdeploy/src/cmdeploy/dovecot/deployer.py
@@ -61,6 +61,9 @@ class DovecotDeployer(Deployer):
                 "Pin-Priority: -1\n"
             ),
             dest="/etc/apt/preferences.d/pin-dovecot",
+            user="root",
+            group="root",
+            mode="644",
         )
 
     def configure(self):


### PR DESCRIPTION
Ensure the preferences.d snippet that pins dovecot packages to block Debian dist-upgrades is owned by root:root and has 644 permissions.

Files in this directory are generally expected to be world readable to ensure unprivileged operations such as apt-get in simulation mode. Having them not world readable breaks such usages.