### PR TITLE
feat: remove dovecot.index.cache files if larger than 500k 

### DIFF
--- a/chatmaild/src/chatmaild/expire.py
+++ b/chatmaild/src/chatmaild/expire.py
@@ -145,6 +145,10 @@ class Expiry:
             changed = True
         if changed:
             self.remove_file(f"{mbox.basedir}/maildirsize")
+        for file in mbox.extrafiles:
+            if "dovecot.index.cache" in file.path.split("/")[-1]:
+                if file.size > 500 * 1024:
+                    self.remove_file(file.path)
 
     def get_summary(self):
         return (

--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -70,12 +70,6 @@ userdb {
 # Mailboxes are stored in the "mail" directory of the vmail user home.
 mail_location = maildir:{{ config.mailboxes_dir }}/%u
 
-# index/cache files are not very useful for chatmail relay operations 
-# but it's not clear how to disable them completely. 
-# According to https://doc.dovecot.org/2.3/settings/advanced/#core_setting-mail_cache_max_size
-# if the cache file becomes larger than the specified size, it is truncated by dovecot 
-mail_cache_max_size = 500K
-
 namespace inbox {
   inbox = yes
 


### PR DESCRIPTION
fix #644 

The dovecot config setting doesn't seem to work; this PR instead expires the dovecot.index.cache files by deleting them regularly.