### PR TITLE
Docker Preparations: remove @docker, consolidate is_in_container()

### DIFF
--- a/cmdeploy/src/cmdeploy/basedeploy.py
+++ b/cmdeploy/src/cmdeploy/basedeploy.py
@@ -3,12 +3,25 @@ import io
 import os
 from contextlib import contextmanager
 
+from pyinfra import host
+from pyinfra.facts.server import Command
 from pyinfra.operations import files, server, systemd
 
 
 def has_systemd():
     """Returns False during Docker image builds or any other non-systemd environment."""
     return os.path.isdir("/run/systemd/system")
+
+
+def is_in_container() -> bool:
+    """Return True if running inside a container (Docker, LXC, etc.)."""
+    return (
+        host.get_fact(
+            Command,
+            "systemd-detect-virt --container --quiet 2>/dev/null && echo yes || true",
+        )
+        == "yes"
+    )
 
 
 @contextmanager

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -108,9 +108,7 @@ def run_cmd(args, out):
     pyinf = "pyinfra --dry" if args.dry_run else "pyinfra"
 
     cmd = f"{pyinf} --ssh-user root {ssh_host} {deploy_path} -y"
-    if ssh_host in ["localhost", "@docker"]:
-        if ssh_host == "@docker":
-            env["CHATMAIL_NOPORTCHECK"] = "True"
+    if ssh_host == "localhost":
         cmd = f"{pyinf} @local {deploy_path} -y"
 
     if version.parse(pyinfra.__version__) < version.parse("3"):
@@ -316,7 +314,7 @@ def add_ssh_host_option(parser):
     parser.add_argument(
         "--ssh-host",
         dest="ssh_host",
-        help="Run commands on 'localhost', via '@docker', or on a specific SSH host "
+        help="Run commands on 'localhost' or on a specific SSH host "
         "instead of chatmail.ini's mail_domain.",
     )
 
@@ -378,9 +376,7 @@ def get_parser():
 
 def get_sshexec(ssh_host: str, verbose=True):
     if ssh_host in ["localhost", "@local"]:
-        return LocalExec(verbose, docker=False)
-    elif ssh_host == "@docker":
-        return LocalExec(verbose, docker=True)
+        return LocalExec(verbose)
     if verbose:
         print(f"[ssh] login to {ssh_host}")
     return SSHExec(ssh_host, verbose=verbose)

--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -2,7 +2,6 @@
 Chat Mail pyinfra deploy.
 """
 
-import os
 import shutil
 import subprocess
 import sys
@@ -28,6 +27,7 @@ from .basedeploy import (
     configure_remote_units,
     get_resource,
     has_systemd,
+    is_in_container,
 )
 from .dovecot.deployer import DovecotDeployer
 from .external.deployer import ExternalTlsDeployer
@@ -584,7 +584,7 @@ def deploy_chatmail(config_path: Path, disable_mail: bool, website_only: bool) -
             Out().red(f"Deploy failed: mtail_address {config.mtail_address} is not available (VPN up?).\n")
             exit(1)
 
-    if not os.environ.get("CHATMAIL_NOPORTCHECK"):
+    if not is_in_container():
         port_services = [
             (["master", "smtpd"], 25),
             ("unbound", 53),

--- a/cmdeploy/src/cmdeploy/dovecot/deployer.py
+++ b/cmdeploy/src/cmdeploy/dovecot/deployer.py
@@ -4,7 +4,7 @@ import urllib.request
 from chatmaild.config import Config
 from pyinfra import host
 from pyinfra.facts.deb import DebPackages
-from pyinfra.facts.server import Arch, Command, Sysctl
+from pyinfra.facts.server import Arch, Sysctl
 from pyinfra.operations import apt, files, server, systemd
 
 from cmdeploy.basedeploy import (
@@ -13,6 +13,7 @@ from cmdeploy.basedeploy import (
     blocked_service_startup,
     configure_remote_units,
     get_resource,
+    is_in_container,
 )
 
 DOVECOT_ARCHIVE_VERSION = "2.3.21+dfsg1-3"
@@ -136,17 +137,6 @@ def _download_dovecot_package(package: str, arch: str) -> tuple[str | None, bool
     return deb_filename, True
 
 
-def _can_set_inotify_limits() -> bool:
-    is_container = (
-        host.get_fact(
-            Command,
-            "systemd-detect-virt --container --quiet 2>/dev/null && echo yes || true",
-        )
-        == "yes"
-    )
-    return not is_container
-
-
 def _configure_dovecot(config: Config, debug: bool = False) -> tuple[bool, bool]:
     """Configures Dovecot IMAP server."""
     need_restart = False
@@ -182,7 +172,7 @@ def _configure_dovecot(config: Config, debug: bool = False) -> tuple[bool, bool]
 
     # as per https://doc.dovecot.org/2.3/configuration_manual/os/
     # it is recommended to set the following inotify limits
-    can_modify = _can_set_inotify_limits()
+    can_modify = not is_in_container()
     for name in ("max_user_instances", "max_user_watches"):
         key = f"fs.inotify.{name}"
         value = host.get_fact(Sysctl)[key]

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -87,9 +87,8 @@ class SSHExec:
 class LocalExec:
     FuncError = FuncError
 
-    def __init__(self, verbose=False, docker=False):
+    def __init__(self, verbose=False):
         self.verbose = verbose
-        self.docker = docker
 
     def __call__(self, call, kwargs=None, log_callback=None):
         if kwargs is None:
@@ -101,10 +100,6 @@ class LocalExec:
         if not title:
             title = call.__name__
         where = "locally"
-        if self.docker:
-            if call == remote.rdns.perform_initial_checks:
-                kwargs["pre_command"] = "docker exec chatmail "
-                where = "in docker"
         if self.verbose:
             print_stderr(f"Running {where}: {title}(**{kwargs})")
             return self(call, kwargs, log_callback=print_stderr)


### PR DESCRIPTION
Separating these into a separate PR:
###  cmdeploy: consolidate container detection into is_in_container() helper
    
Both deployers.py (CHATMAIL_NOPORTCHECK env var) and dovecot/deployer.py
(_can_set_inotify_limits function) used separate container detection logic.
Replace both with a single is_in_container() helper in basedeploy.py using
the simpler systemd-detect-virt -c pattern.

###  cmdeploy/sshexec: remove dead @docker SSH host
    
The `@docker` SSH host was added in Docker development to route
cmdeploy commands into a running container from outside. This is no
longer needed because chatmail-init.sh deploys with `@local` inside
the container, and all cmdeploy commands (test, dns, status) work