### PR TITLE
refactor: Rename filtermail_http_port to filtermail_http_port_incoming

### DIFF
--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -38,7 +38,9 @@ class Config:
         self.filtermail_smtp_port_incoming = int(
             params.get("filtermail_smtp_port_incoming", "10081")
         )
-        self.filtermail_http_port = int(params.get("filtermail_http_port", "10082"))
+        self.filtermail_http_port_incoming = int(
+            params.get("filtermail_http_port_incoming", "10082")
+        )
         self.postfix_reinject_port = int(params.get("postfix_reinject_port", "10025"))
         self.postfix_reinject_port_incoming = int(
             params.get("postfix_reinject_port_incoming", "10026")

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -74,7 +74,7 @@ http {
 		access_log syslog:server=unix:/dev/log,facility=local7;
 
 		location /mxdeliv/ {
-		    proxy_pass http://127.0.0.1:{{ config.filtermail_http_port }};
+		    proxy_pass http://127.0.0.1:{{ config.filtermail_http_port_incoming }};
 		}
 
 		location / {


### PR DESCRIPTION
Since http port will be used for MTA-to-MTA,
it should be suffixed with "incoming" for consistency.

This will also make it clearer if we decide to
introduce client-relay http channel in the future.