### PR TITLE
fix(cmdeploy): explicitly install resolvconf

### DIFF
--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -158,7 +158,7 @@ class UnboundDeployer(Deployer):
         with blocked_service_startup():
             apt.packages(
                 name="Install unbound",
-                packages=["unbound", "unbound-anchor", "dnsutils"],
+                packages=["unbound", "unbound-anchor", "dnsutils", "resolvconf"],
             )
 
     def configure(self):


### PR DESCRIPTION
Since ff541b8 introduced APT::Install-Recommends "false", we need to explicitly install resolvconf. Fixes DNS breakage caused by apt.upgrade with auto_remove=True purging resolvconf as an orphan and removing 'nameserver 127.0.0.1' in /etc/resolv.conf that pointed to the local unbound, in consequence DNS resolution breaks and filtermail-incoming exits because it cannot find resolvers.