### PR TITLE
chore(tests): remove --slow from cmdeploy test

### DIFF
--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -194,12 +194,6 @@ def status_cmd(args, out):
 
 
 def test_cmd_options(parser):
-    parser.add_argument(
-        "--slow",
-        dest="slow",
-        action="store_true",
-        help="also run slow tests",
-    )
     add_ssh_host_option(parser)
 
 
@@ -221,8 +215,6 @@ def test_cmd(args, out):
         "-v",
         "--durations=5",
     ]
-    if args.slow:
-        pytest_args.append("--slow")
     ret = out.run_ret(pytest_args, env=env)
     return ret
 

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -221,7 +221,6 @@ def test_rewrite_subject(cmsetup, maildata):
     assert "Subject: Unencrypted subject" not in rcvd_msg
 
 
-@pytest.mark.slow
 def test_exceed_rate_limit(cmsetup, gencreds, maildata, chatmail_config):
     """Test that the per-account send-mail limit is exceeded."""
     user1, user2 = cmsetup.gen_users(2)
@@ -244,7 +243,6 @@ def test_exceed_rate_limit(cmsetup, gencreds, maildata, chatmail_config):
     pytest.fail("Rate limit was not exceeded")
 
 
-@pytest.mark.slow
 def test_expunged(remote, chatmail_config):
     outdated_days = int(chatmail_config.delete_mails_after) + 1
     find_cmds = [

--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -23,24 +23,11 @@ def _is_ip(domain):
         return False
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--slow", action="store_true", default=False, help="also run slow tests"
-    )
-
-
 def pytest_configure(config):
     config._benchresults = {}
     config.addinivalue_line(
         "markers", "slow: mark test to require --slow option to run"
     )
-
-
-def pytest_runtest_setup(item):
-    markers = list(item.iter_markers(name="slow"))
-    if markers:
-        if not item.config.getoption("--slow"):
-            pytest.skip("skipping slow test, use --slow to run")
 
 
 def _get_chatmail_config():


### PR DESCRIPTION
The new CI tool https://pypi.org/project/cmlxc/ doesn't use the `cmdeploy test --slow` option, so 2 tests are skipped in the current CI.

So I tried adding `--slow` to cmlxc, but the tests simply are not very slow anymore :D local LXC containers have much less turnaround times:

```
  ============================= slowest 5 durations ==============================
  7.61s call     src/cmdeploy/tests/online/test_1_basic.py::test_exceed_rate_limit
  6.24s call     src/cmdeploy/tests/online/test_2_deltachat.py::TestEndToEndDeltaChat::test_read_receipts_between_instances
  5.01s call     src/cmdeploy/tests/online/test_2_deltachat.py::TestMetadataTokens::test_set_get_metadata
  4.23s call     src/cmdeploy/tests/online/test_0_login.py::test_login_basic_functioning[imap]
  3.99s call     src/cmdeploy/tests/online/test_0_login.py::test_login_basic_functioning[smtp]
  ============================= 77 passed in 24.63s ==============================
```

So let's remove `--slow` completely :) only deleted code is good code.