### PR TITLE
feat: do not bind SMTP client sockets to public addresses

### DIFF
--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import iniconfig
@@ -47,8 +46,6 @@ class Config:
         )
         self.mtail_address = params.get("mtail_address")
         self.disable_ipv6 = params.get("disable_ipv6", "false").lower() == "true"
-        self.addr_v4 = os.environ.get("CHATMAIL_ADDR_V4", "")
-        self.addr_v6 = os.environ.get("CHATMAIL_ADDR_V6", "")
         self.acme_email = params.get("acme_email", "")
         self.imap_rawlog = params.get("imap_rawlog", "false").lower() == "true"
         self.imap_compress = params.get("imap_compress", "false").lower() == "true"

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -101,9 +101,6 @@ def run_cmd(args, out):
     env["CHATMAIL_WEBSITE_ONLY"] = "True" if args.website_only else ""
     env["CHATMAIL_DISABLE_MAIL"] = "True" if args.disable_mail else ""
     env["CHATMAIL_REQUIRE_IROH"] = "True" if require_iroh else ""
-    if not args.dns_check_disabled:
-        env["CHATMAIL_ADDR_V4"] = remote_data.get("A") or ""
-        env["CHATMAIL_ADDR_V6"] = remote_data.get("AAAA") or ""
     deploy_path = importlib.resources.files(__package__).joinpath("run.py").resolve()
     pyinf = "pyinfra --dry" if args.dry_run else "pyinfra"
 

--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -69,15 +69,6 @@ mynetworks = 127.0.0.0/8
 {% else %}
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 {% endif %}
-{% if config.addr_v4 %}
-smtp_bind_address = {{ config.addr_v4 }}
-{% endif %}
-{% if config.addr_v6 %}
-smtp_bind_address6 = {{ config.addr_v6 }}
-{% endif %}
-{% if config.addr_v4 or config.addr_v6 %}
-smtp_bind_address_enforce = yes
-{% endif %}
 mailbox_size_limit = 0
 message_size_limit = {{config.max_message_size}}
 recipient_delimiter = +

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,5 +16,6 @@ Contributions and feedback welcome through the https://github.com/chatmail/relay
     proxy
     migrate
     overview
+    reverse_dns
     related
     faq

--- a/doc/source/reverse_dns.rst
+++ b/doc/source/reverse_dns.rst
@@ -1,0 +1,64 @@
+Configuring reverse DNS
+=======================
+
+Some email servers reject the emails
+if they don't pass `FCrDNS`_ check, also known as `iprev`_ check.
+
+.. _FCrDNS: https://en.wikipedia.org/wiki/Forward-confirmed_reverse_DNS
+.. _iprev: https://datatracker.ietf.org/doc/html/rfc8601#section-3
+
+Passing the check requires that the IP address that email is sent from
+should have a ``PTR`` record pointing to the domain name of the server,
+and domain name record should have an ``A/AAAA`` record
+pointing to the IP address.
+
+Modern email relies on DKIM and SPF for authentication,
+while iprev check exists for
+`historical reasons <https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-reverse-mapping-considerations-06#section-2.1>`_.
+Chatmail relays don't resolve ``PTR`` records,
+so you can ignore this section if configuring ``PTR`` records
+is difficult and federation with legacy email servers that don't accept
+valid DKIM signature for authentication is not important.
+
+Multi-homed setups
+------------------
+
+If you have a server with multiple IP addresses,
+also known as multi-homed setup,
+and don't publish all IP addresses in DNS,
+you need to make sure you are using
+the published address when making outgoing connections.
+
+For example, your server may have a static IP
+address, and a so-called Floating IP or Virtual IP
+that can be moved between servers in case of
+migration or for failover.
+By using Floating IP you can avoid downtime
+and keep the IP address reputation
+for destinatinons that rely on IP reputation and IP blocklists.
+In this case you will only publish
+the Floating IP to DNS and only use the static IP
+to SSH into the server.
+
+If you have such setup, make sure that
+you not only set ``PTR`` records for the Floating IP,
+but make outgoing connections using the Floating IP.
+Otherwise reverse DNS check succeed,
+but forward check making sure your domain name points
+to the IP address will fail.
+Such setup is indistinguishable from someone
+setting IP address ``PTR`` with the domain they don't own
+and as a result don't succeed.
+
+On Linux you can configure source IP address with ``ip route`` command,
+for example:
+::
+
+  ip route change default via <default-gateway> dev eth0 src <source-address>
+
+Make sure to persist the change after verifying it is working.
+You can check what your outgoing IP address is
+with ``curl icanhazip.com``.
+Check both the IPv4 and IPv6 addresses.
+For IPv4 address use ``curl ipv4.icanhazip.com`` or ``curl -4 icanhazip.com``
+and similarly for IPv6 if you have it.


### PR DESCRIPTION
This change reverts 06560dd0710167d1e819f10b3e8fe1a6285e7a6c

Main reason for using the same address for sending as the one used in DNS is to pass FCrDNS
(forward-confirmed reverse DNS) checks:
IP address used by SMTP client should resolve
to the domain which in turn resolves to the same IP. chatmail relays don't do check reverse DNS
for incoming connections,
but other email servers may do and reject email
if the check does not pass.

Most chatmail relays only have one IP address per address family, so this configuration does not change anything.

For chatmail relays that have multiple addresses
and only publishing one IP to DNS,
source address used for outgoing SMTP connections
should be the public IP.

This can be ensured by configuring the source
address in the routing table,
e.g. with the `src` argument
to `ip route add/change/replace` command.

Solving this by binding SMTP client address
on the application level prevents chatmail relays
from configuring alternative routes.

Besides, some chatmail relays are NATed
and NAT is responsible for translating the address to the public one, in which case using `smtp_bind_address_enforce`
will result in unnecessarily deferring all mails.