### PR TITLE
docs(doc/README.md): scripts/initenv.sh should be used for building the docs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,12 +4,14 @@
 
 You can use the `make` command and `make html` to build web pages. 
 
-You need a Python environment where the following install was excuted: 
-
-    pip install furo sphinx-autobuild
+You need a Python environment with `sphinx` and other
+dependencies, you can create it by running `scripts/initenv.sh`
+from the repository root.
 
 To develop/change documentation, you can then do: 
 
+    . venv/bin/activate
+    cd doc
     make auto 
 
 A page will open at https://127.0.0.1:8000/ serving the docs and it will 


### PR DESCRIPTION
doc/README.md was outdated, it did not include sphinxcontrib-mermaid. Better use scripts/initenv.sh which already installs all dependencies and is used in CI.