### PR TITLE
feat(doc/docker): Introduce docker images in documentation

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -101,6 +101,15 @@ steps. Please substitute it with your own domain.
    configure at your DNS provider (it can take some time until they are
    public).
 
+
+
+Docker installation
+-------------------
+
+There is experimental support for running chatmail via Docker.
+A monolithic image based on the above cmdeploy method is available `through a separate repository <https://github.com/chatmail/docker/pkgs/container/docker>`_.
+See the `chatmail/docker README <https://github.com/chatmail/docker>`_ for full setup instructions.
+
 Other helpful commands
 ----------------------
 


### PR DESCRIPTION
This adds a small section referring to the automatically built docker images, separated this from #934 so we can decide separately whether we want to ship this with 0.10.0.