### PR TITLE
fix(mtail): start after networking is fully up

### DIFF
--- a/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
+++ b/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=mtail
+After=multi-user.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
When mtail is exporting to a VPN interface, it fails to come up, so add a "After: multi-user-target" to the systemd unit so it only starts when everything should be up:

```
~ # systemd-analyze critical-chain
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

graphical.target @17.991s
└─multi-user.target @17.991s
  └─prometheus-node-exporter.service @17.991s
    └─wg-quick@wg0.service @7.891s +10.059s
      └─nss-lookup.target @7.888s
        └─unbound.service @7.845s +42ms
          └─network.target @7.840s
            └─networking.service @1.648s +6.192s
              └─local-fs.target @1.645s
                └─run-user-0.mount @10.793s
                  └─swap.target @699ms
                    └─dev-disk-by\x2duuid-4703840a\x2dd93f\x2d4b4a\x2d89df\x2ddd262c1f6a1b.swap @690ms +8ms
                      └─dev-disk-by\x2duuid-4703840a\x2dd93f\x2d4b4a\x2d89df\x2ddd262c1f6a1b.device @678ms
```