### PR TITLE
fix(mtail): correct boot ordering and deploy restart logic

### DIFF
--- a/cmdeploy/src/cmdeploy/mtail/deployer.py
+++ b/cmdeploy/src/cmdeploy/mtail/deployer.py
@@ -37,7 +37,7 @@ class MtailDeployer(Deployer):
     def configure(self):
         # Using our own systemd unit instead of `/usr/lib/systemd/system/mtail.service`.
         # This allows to read from journalctl instead of log files.
-        files.template(
+        unit = files.template(
             src=get_resource("mtail/mtail.service.j2"),
             dest="/etc/systemd/system/mtail.service",
             user="root",
@@ -55,7 +55,8 @@ class MtailDeployer(Deployer):
             group="root",
             mode="644",
         )
-        self.need_restart = mtail_conf.changed
+        self.unit_changed = unit.changed
+        self.need_restart = unit.changed or mtail_conf.changed
 
     def activate(self):
         systemd.service(
@@ -64,5 +65,6 @@ class MtailDeployer(Deployer):
             running=bool(self.mtail_address),
             enabled=bool(self.mtail_address),
             restarted=self.need_restart,
+            daemon_reload=self.unit_changed,
         )
         self.need_restart = False

--- a/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
+++ b/cmdeploy/src/cmdeploy/mtail/mtail.service.j2
@@ -1,11 +1,13 @@
 [Unit]
 Description=mtail
-After=multi-user.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 ExecStart=/bin/sh -c "journalctl -f -o short-iso -n 0 | /usr/local/bin/mtail --address={{ address }} --port={{ port }} --progs /etc/mtail --logtostderr --logs -"
 Restart=on-failure
+RestartSec=2s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Correct the systemd unit modifications in 98bc1503 that lead to startup failures in some instances. Switch to `[After,Wants] = network-online.target` and add `RestartSec=2s` to give late-binding more interfaces time to appear.

In the deployer, capture the `files.template()` return value and appropriately set need_restart and daemon_reload.