### PR TITLE
Security: Shell Command Injection in rshell.py

### DIFF
--- a/cmdeploy/src/cmdeploy/remote/rshell.py
+++ b/cmdeploy/src/cmdeploy/remote/rshell.py
@@ -8,8 +8,12 @@ def log_progress(data):
 
 
 def shell(command, fail_ok=False, print=print):
-    print(f"$ {command}")
-    args = dict(shell=True)
+    if isinstance(command, list):
+        cmd_str = " ".join(command)
+    else:
+        cmd_str = command
+    print(f"$ {cmd_str}")
+    args = dict(shell=False)
     if fail_ok:
         args["stderr"] = DEVNULL
     try:
@@ -21,7 +25,7 @@ def shell(command, fail_ok=False, print=print):
 
 
 def get_systemd_running():
-    lines = shell("systemctl --type=service --state=running").split("\n")
+    lines = shell(["systemctl", "--type=service", "--state=running"]).split("\n")
     return [line for line in lines if line.startswith("  ")]
 
 
@@ -31,8 +35,8 @@ def write_numbytes(path, num):
 
 
 def dovecot_recalc_quota(user):
-    shell(f"doveadm quota recalc -u {user}")
-    output = shell(f"doveadm quota get -u {user}")
+    shell(["doveadm", "quota", "recalc", "-u", user])
+    output = shell(["doveadm", "quota", "get", "-u", user])
     #
     # Quota name Type    Value  Limit                                              %
     # User quota STORAGE     5 102400                                              0


### PR DESCRIPTION
## Summary

Security: Shell Command Injection in rshell.py

## Problem

**Severity**: `High` | **File**: `cmdeploy/src/cmdeploy/remote/rshell.py:L10`

The shell() function uses shell=True which is vulnerable to command injection if user-controlled input is passed to it. The function is used throughout the codebase including in rdns.py for DNS queries.

## Solution

Use shell=False and pass commands as lists to avoid shell injection. If shell=True is required, validate and sanitize all input thoroughly.

## Changes

- `cmdeploy/src/cmdeploy/remote/rshell.py` (modified)