### PR TITLE
fix(nginx): align port 80 redirect logging

### DIFF
--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -159,6 +159,7 @@ http {
 		{% endif %}
 
 		return 301 https://$host$request_uri;
+		access_log syslog:server=unix:/dev/log,facility=local7;
 	}
 
 	{% if config.tls_cert_mode == "acme" %}


### PR DESCRIPTION
The port 80 redirect server block has no access_log defined, so it is falling back to the default of a physical file. This is not aligned with the rest of the configured logging to systemd.

Implement the expected logging path for the port 80 redirect server