### PR TITLE
docs: add scripts/initenv.sh to upgrade instructions

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -60,6 +60,7 @@ and run the following commands:
    ::
 
        git pull origin main --rebase --autostash
+       scripts/initenv.sh
        scripts/cmdeploy run
 
 If you don't want the latest development version,


### PR DESCRIPTION
Someone was missing a dependency which was introduced by `git pull`, this makes sure that all dependencies are there as well.