### PR TITLE
fix: set relay restrictions per smtpd service with default reject

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -53,7 +53,8 @@ smtpd_tls_exclude_ciphers = aNULL, RC4, MD5, DES
 # See <https://www.postfix.org/FORWARD_SECRECY_README.html#server_fs>.
 tls_preempt_cipherlist = yes
 
-smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+# Reject by default, override per smtpd in master.cf
+smtpd_relay_restrictions = reject
 myhostname = {{ config.postfix_myhostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases

--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -17,6 +17,7 @@ smtp      inet  n       -       y       -       -       smtpd
   -o smtpd_tls_security_level=encrypt
   -o smtpd_tls_mandatory_protocols=>=TLSv1.2
   -o smtpd_proxy_filter=127.0.0.1:{{ config.filtermail_smtp_port_incoming }}
+  -o smtpd_relay_restrictions=reject_unauth_destination
 submission inet n       -       y       -       5000    smtpd
   -o syslog_name=postfix/submission
   -o smtpd_tls_security_level=encrypt
@@ -81,12 +82,14 @@ filter    unix -        n       n       -       -       lmtp
   -o syslog_name=postfix/reinject
   -o milter_macro_daemon_name=ORIGINATING
   -o cleanup_service_name=authclean
+  -o smtpd_relay_restrictions=permit_mynetworks,reject
 {% if not config.ipv4_relay %}  -o smtpd_milters=unix:opendkim/opendkim.sock
 {% endif %}
 
 # Local SMTP server for reinjecting incoming filtered mail 
 127.0.0.1:{{ config.postfix_reinject_port_incoming }} inet  n       -       n       -       100      smtpd
   -o syslog_name=postfix/reinject_incoming
+  -o smtpd_relay_restrictions=reject_unauth_destination
 
 # Cleanup `Received` headers for authenticated mail
 # to avoid leaking client IP.


### PR DESCRIPTION
We never want to defer email with a tepporary error when it has destination that we cannot deliver locally and don't want to relay. To avoid doing this accidentally, set default action to "reject" and then override it with the minimal restrictions per smtpd.

Submission ports already had smtpd_relay_restrictions=permit_sasl_authenticated,reject override.

Each smtpd port must have at least one of
reject, reject_unauth_destination, defer, defer_if_permit, defer_unauth_destination according to <https://www.postfix.org/postconf.5.html#smtpd_relay_restrictions>.

I have set smtpd_relay_restrictions=reject_unauth_destination for port 25 and incoming reinject port, and smtpd_relay_restrictions=permit_mynetworks,reject for outgoing reinject port.