### PR TITLE
ci: auto-trigger docker build on release tag push

### DIFF
--- a/.github/workflows/docker-dispatch.yaml
+++ b/.github/workflows/docker-dispatch.yaml
@@ -9,6 +9,7 @@ name: Trigger Docker build
 on:
   push:
     branches: [main]
+    tags: ['[0-9]+.[0-9]+.[0-9]+']
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
docker-dispatch.yaml previously only fired on push to main and manual workflow_dispatch, so tagging 1.11.0 did not build the release image. This change adds matching of X.Y.Z tag.