### PR TITLE
fix: reduce maxproc for filtermail-transport LMTP client to 500

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -113,7 +113,7 @@ authclean unix  n       -       -       -       0       cleanup
 # so while filtermail-transport tries to deliver the message,
 # possibly waiting for a long connection timeout
 # or talking to a slow server, LMTP client cannot be reused.
-lmtp-filtermail unix  -       -       y       -       1000       lmtp
+lmtp-filtermail unix  -       -       y       -       500       lmtp
   -o syslog_name=postfix/lmtp-filtermail
   -o lmtp_header_checks=
   -o lmtp_tls_security_level=none


### PR DESCRIPTION
This further reduces it from 1000.
For small servers this may be needed if they have low memory. For large servers may be increased manually for now.