### PR TITLE
test: remove unsupported delete_server_after config

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -177,11 +177,22 @@ def test_hide_senders_ip_address(cmfactory, ssl_context):
 
     chat.send_text("testing submission header cleanup")
     user2.wait_for_incoming_msg()
+
     addr = user2.get_config("addr")
     host = addr.split("@")[1].strip("[").strip("]")
     pw = user2.get_config("mail_pw")
     mailbox = imap_tools.MailBox(host, ssl_context=ssl_context)
     mailbox.login(addr, pw)
-    msgs = list(mailbox.fetch(mark_seen=False))
+
+    deadline = time.time() + 10
+    msgs = []
+
+    while time.time() < deadline:
+        mailbox.folder.set("INBOX")
+        msgs = list(mailbox.fetch(criteria="ALL", mark_seen=False))
+        if msgs:
+            break
+        time.sleep(0.5)
+
     assert msgs, "expected at least one message"
-    assert public_ip not in msgs[0].obj.as_string()
+    assert public_ip not in msgs[-1].obj.as_string()

--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -360,9 +360,9 @@ class ChatmailACFactory:
                 )
             futures.append(future)
 
-            # ensure messages stay in INBOX so that they can be
-            # concurrently fetched via extra IMAP connections during tests
-            account.set_config("delete_server_after", "10")
+            ## ensure messages stay in INBOX so that they can be
+            ## concurrently fetched via extra IMAP connections during tests
+            ##account.set_config("delete_server_after", "10")
             accounts.append(account)
 
         for future in futures:


### PR DESCRIPTION
## summary

remove the unsupported deltachat config key `delete_server_after` from the cmdeploy test account setup.

deltachat rpc/server 2.50.0 rejects this setting with:

```text
unknown key "delete_server_after": matching variant not found