### PR TITLE
fix: pin chatmail core to 2.49.0

### DIFF
--- a/cmdeploy/pyproject.toml
+++ b/cmdeploy/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
   "pytest-xdist", 
   "execnet",
   "imap_tools",
-  "deltachat-rpc-client",
-  "deltachat-rpc-server",
+  "deltachat-rpc-client==2.49.0",
+  "deltachat-rpc-server==2.49.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
2.50.0 has delete_server_after config removed,
but it is still used in the tests.