### PR TITLE
test: update deltachat 2.50 ci compatibility

### DIFF
--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,9 +20,9 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@b7c0a1faca0deec686fce0d648275fb1bdf10f11
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
     with:
-      cmlxc_version: b7c0a1faca0deec686fce0d648275fb1bdf10f11
+      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,9 +20,9 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@v0.14.6
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@b7c0a1faca0deec686fce0d648275fb1bdf10f11
     with:
-      cmlxc_version: v0.14.6
+      cmlxc_version: b7c0a1faca0deec686fce0d648275fb1bdf10f11
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@v0.14.6
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@b7c0a1faca0deec686fce0d648275fb1bdf10f11
     with:
-      cmlxc_version: v0.14.6
+      cmlxc_version: b7c0a1faca0deec686fce0d648275fb1bdf10f11
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@b7c0a1faca0deec686fce0d648275fb1bdf10f11
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
     with:
-      cmlxc_version: b7c0a1faca0deec686fce0d648275fb1bdf10f11
+      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test


### PR DESCRIPTION
## summary

this pr updates the relay ci/test setup for compatibility with deltachat rpc/server 2.50.0.

## changes

### remove unsupported deltachat config

the cmdeploy test account setup previously configured:

```python
account.set_config("delete_server_after", "10")
```

deltachat rpc/server 2.50.0 now rejects this key with:

```text
unknown key "delete_server_after": matching variant not found
```

which caused account setup failures before the affected tests could run.

the setting has been removed/commented out because:

* the original purpose is currently unclear
* deltachat core maintainers indicated the option is no longer supported
* replacing it with another behavior-changing config would be speculative

### improve sender ip cleanup imap test resilience

`test_hide_senders_ip_address` was updated to:

* explicitly select `INBOX`
* poll imap with a timeout
* fetch using `criteria="ALL"`
* inspect the newest matching message

this is intended to reduce timing sensitivity when validating raw message headers after deltachat receive processing.

### pin cmlxc ci workflow revision

the reusable `cmlxc` workflow reference was pinned to a commit containing the matching `delete_server_after` cleanup in `relay_minitest`, since the previous workflow tag still referenced the obsolete config.

## status

draft/investigation pr for deltachat 2.50 compatibility validation.
