### PR TITLE
test: update deltachat 2.50 ci compatibility

### DIFF
--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,9 +20,9 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@17e0d871869ad953268eefa0a448e95c73b9197d
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@6d64dff5cf1ad3ccd37f7b51ee0a96bbdc9c84d2
     with:
-      cmlxc_version: 17e0d871869ad953268eefa0a448e95c73b9197d
+      cmlxc_version: 6d64dff5cf1ad3ccd37f7b51ee0a96bbdc9c84d2
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,9 +20,9 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@17e0d871869ad953268eefa0a448e95c73b9197d
     with:
-      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
+      cmlxc_version: 17e0d871869ad953268eefa0a448e95c73b9197d
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,9 +20,9 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@v0.14.6
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
     with:
-      cmlxc_version: v0.14.6
+      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@v0.14.6
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
     with:
-      cmlxc_version: v0.14.6
+      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@17e0d871869ad953268eefa0a448e95c73b9197d
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@6d64dff5cf1ad3ccd37f7b51ee0a96bbdc9c84d2
     with:
-      cmlxc_version: 17e0d871869ad953268eefa0a448e95c73b9197d
+      cmlxc_version: 6d64dff5cf1ad3ccd37f7b51ee0a96bbdc9c84d2
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@8807cbbf386f32294f08963a8295c9820218ae01
+    uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@17e0d871869ad953268eefa0a448e95c73b9197d
     with:
-      cmlxc_version: 8807cbbf386f32294f08963a8295c9820218ae01
+      cmlxc_version: 17e0d871869ad953268eefa0a448e95c73b9197d
       cmlxc_commands: |
         cmlxc init 
         # single cmdeploy relay test

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -167,20 +167,20 @@ class TestEndToEndDeltaChat:
                 assert "error" not in m.get_info()
             time.sleep(1)
 
-
 def test_hide_senders_ip_address(cmfactory, ssl_context):
     public_ip = requests.get("http://icanhazip.com").content.decode().strip()
     assert ipaddress.ip_address(public_ip)
 
     user1, user2 = cmfactory.get_online_accounts(2)
+    user1.set_config("bcc_self", "1")
     chat = cmfactory.get_accepted_chat(user1, user2)
 
     chat.send_text("testing submission header cleanup")
     user2.wait_for_incoming_msg()
 
-    addr = user2.get_config("addr")
+    addr = user1.get_config("addr")
     host = addr.split("@")[1].strip("[").strip("]")
-    pw = user2.get_config("mail_pw")
+    pw = user1.get_config("mail_pw")
     mailbox = imap_tools.MailBox(host, ssl_context=ssl_context)
     mailbox.login(addr, pw)
 
@@ -196,4 +196,3 @@ def test_hide_senders_ip_address(cmfactory, ssl_context):
 
     assert msgs, "expected at least one message"
     assert public_ip not in msgs[-1].obj.as_string()
-

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -177,11 +177,23 @@ def test_hide_senders_ip_address(cmfactory, ssl_context):
 
     chat.send_text("testing submission header cleanup")
     user2.wait_for_incoming_msg()
+
     addr = user2.get_config("addr")
     host = addr.split("@")[1].strip("[").strip("]")
     pw = user2.get_config("mail_pw")
     mailbox = imap_tools.MailBox(host, ssl_context=ssl_context)
     mailbox.login(addr, pw)
-    msgs = list(mailbox.fetch(mark_seen=False))
+
+    deadline = time.time() + 10
+    msgs = []
+
+    while time.time() < deadline:
+        mailbox.folder.set("INBOX")
+        msgs = list(mailbox.fetch(criteria="ALL", mark_seen=False))
+        if msgs:
+            break
+        time.sleep(0.5)
+
     assert msgs, "expected at least one message"
-    assert public_ip not in msgs[0].obj.as_string()
+    assert public_ip not in msgs[-1].obj.as_string()
+

--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -360,9 +360,9 @@ class ChatmailACFactory:
                 )
             futures.append(future)
 
-            # ensure messages stay in INBOX so that they can be
-            # concurrently fetched via extra IMAP connections during tests
-            account.set_config("delete_server_after", "10")
+           # # ensure messages stay in INBOX so that they can be
+           # # concurrently fetched via extra IMAP connections during tests
+           # account.set_config("delete_server_after", "10")
             accounts.append(account)
 
         for future in futures:


### PR DESCRIPTION
## summary

this pr updates relay ci/test behavior for compatibility with deltachat rpc/server 2.50.0.

## changes

### remove unsupported deltachat config

the cmdeploy test account setup previously configured:

```python
account.set_config("delete_server_after", "10")
```

deltachat rpc/server 2.50.0 now rejects this key with:

```text
unknown key "delete_server_after": matching variant not found
```

which caused account setup failures before tests could run.

the unsupported setting has been removed/commented out from the relay-side cmdeploy test setup.

### update cmlxc workflow pin

the reusable `cmlxc` workflow reference is pinned to a newer commit containing the matching `relay_minitest` compatibility fixes, since the previously referenced `v0.14.6` workflow still used the obsolete config.

### improve sender ip cleanup test handling

`test_hide_senders_ip_address` has been updated to reduce timing sensitivity and mailbox visibility issues during raw imap inspection by:

* enabling `bcc_self`
* explicitly selecting `INBOX`
* polling imap with a timeout
* fetching using `criteria="ALL"`
* inspecting the newest matching message

this allows the test to inspect a server-visible copy of the submitted message even after deltachat receive processing.

## current status

the unsupported deltachat config issue now appears resolved in both cmdeploy and relay_minitest paths.

this pr also updates the sender ip cleanup tests to work with deltachat rpc/server 2.50 mailbox behavior observed during ci runs.

- relevant pr on [cmlxc](https://github.com/chatmail/cmlxc/pull/21) with priority merge