### PR TITLE
test: set socket security for IMAP and SMTP to "TLS" in "dclogin"

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -349,9 +349,9 @@ class ChatmailACFactory:
                 qr = (
                     f"dclogin:{addr}"
                     f"?p={password}&v=1"
-                    f"&ih={domain}&ip=993"
-                    f"&sh={domain}&sp=465"
-                    f"&ic=3&ss=default"
+                    f"&ih={domain}&ip=993&is=ssl"
+                    f"&sh={domain}&sp=465&ss=ssl"
+                    f"&ic=3"
                 )
                 future = account.add_transport_from_qr.future(qr)
             else:


### PR DESCRIPTION
With "default" (like it was for SMTP) or not set (like it was for IMAP), both TLS and STARTTLS are tried.
Trying STARTTLS against TLS port is going to timeout because in STARTTLS server talks first,
but when connected to TLS port the server
waits for TLS client hello and does not send anything.

Should not actually matter in tests which connect successfully on the first try because implicit TLS is tried first.