### PR TITLE
fix: Always deploy unbound.conf.d/chatmail.conf

### DIFF
--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -171,16 +171,14 @@ class UnboundDeployer(Deployer):
                 "unbound-anchor -a /var/lib/unbound/root.key || true",
             ],
         )
-        if self.config.disable_ipv6:
-            self.ensure_directory(
-                path="/etc/unbound/unbound.conf.d",
-            )
-            self.put_template(
-                "unbound/unbound.conf.j2",
-                "/etc/unbound/unbound.conf.d/chatmail.conf",
-            )
-        else:
-            self.remove_file("/etc/unbound/unbound.conf.d/chatmail.conf")
+        self.ensure_directory(
+            path="/etc/unbound/unbound.conf.d",
+        )
+        self.put_template(
+            "unbound/unbound.conf.j2",
+            "/etc/unbound/unbound.conf.d/chatmail.conf",
+            disable_ipv6=self.config.disable_ipv6,
+        )
 
     def activate(self):
         server.shell(

--- a/cmdeploy/src/cmdeploy/unbound/unbound.conf.j2
+++ b/cmdeploy/src/cmdeploy/unbound/unbound.conf.j2
@@ -1,5 +1,7 @@
 # Managed by cmdeploy
 server:
+{% if disable_ipv6 %}
   interface: 127.0.0.1
   do-ip6: no
+{% endif %}
   cache-max-negative-ttl: 0


### PR DESCRIPTION
This fixes issue with negative cache
being only disabled in ipv4-only mode.

Follow up to #992