### PR TITLE
fix: still overwrite /etc/resolv.conf if it is a symbolic link

### DIFF
--- a/cmdeploy/src/cmdeploy/basedeploy.py
+++ b/cmdeploy/src/cmdeploy/basedeploy.py
@@ -166,7 +166,7 @@ class Deployer:
             return self.put_template(src, dest, **kwargs)
         return self.put_file(src, dest)
 
-    def put_file(self, src, dest, mode="644"):
+    def put_file(self, src, dest, mode="644", **kwargs):
         if isinstance(src, str):
             src = get_resource(src)
         res = files.put(
@@ -176,6 +176,7 @@ class Deployer:
             user="root",
             group="root",
             mode=mode,
+            **kwargs,
         )
 
         return self._update_restart_signals(dest, res)

--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -164,6 +164,7 @@ class UnboundDeployer(Deployer):
         self.put_file(
             src=BytesIO(b"nameserver 127.0.0.1\nnameserver 9.9.9.9\n"),
             dest="/etc/resolv.conf",
+            force=True,
         )
         server.shell(
             name="Generate root keys for validating DNSSEC",


### PR DESCRIPTION
fix #515 