### PR TITLE
feat: Extend IMAP METADATA to have a unixtimestamp key

### DIFF
--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -125,6 +125,8 @@ class MetadataDictProxy(DictProxy):
                         case "maxsmtprecipients":
                             # postfix default  (see "postconf smtpd_recipient_limit")
                             return "O1000\n"
+                        case "unixtimestamp":
+                            return f"O{int(time.time())}\n"
 
         logging.warning(f"lookup ignored: {parts!r}")
         return "N\n"


### PR DESCRIPTION
proof of concept born from a relay development discussion:

This would permit the ability for core to request a timestamp from the relay and figure out if there's significant clock skew so we can send a Device Message notification about it.

Cell phones are highly unlikely to have a clock skew problem.

Desktop clients are the primary place we'd expect to encounter this clock skew issue which can cause messages to be sorted out of order on the recipient.

If a profile has at least three relays, it would be possible to confidently detect if the clock skew is really server side if only one relay is showing a clock skew issue.

We have to consider network latency in this calculation and relays can be anywhere in the world, so I suppose in core we'd have to either know the latency when calculating or just permit a couple seconds worth of skew before alerting.