### PR TITLE
WIP: chore(update): use dovecot 2.3 built for Debian 13

### DIFF
--- a/cmdeploy/src/cmdeploy/dovecot/deployer.py
+++ b/cmdeploy/src/cmdeploy/dovecot/deployer.py
@@ -19,12 +19,12 @@ DOVECOT_ARCHIVE_VERSION = "2.3.21+dfsg1-3"
 DOVECOT_PACKAGE_VERSION = f"1:{DOVECOT_ARCHIVE_VERSION}"
 
 DOVECOT_SHA256 = {
-    ("core", "amd64"): "dd060706f52a306fa863d874717210b9fe10536c824afe1790eec247ded5b27d",
-    ("core", "arm64"): "e7548e8a82929722e973629ecc40fcfa886894cef3db88f23535149e7f730dc9",
-    ("imapd", "amd64"): "8d8dc6fc00bbb6cdb25d345844f41ce2f1c53f764b79a838eb2a03103eebfa86",
-    ("imapd", "arm64"): "178fa877ddd5df9930e8308b518f4b07df10e759050725f8217a0c1fb3fd707f",
-    ("lmtpd", "amd64"): "2f69ba5e35363de50962d42cccbfe4ed8495265044e244007d7ccddad77513ab",
-    ("lmtpd", "arm64"): "89f52fb36524f5877a177dff4a713ba771fd3f91f22ed0af7238d495e143b38f",
+    ("core", "amd64"): "b24dcb26eee8fe2f769290fe4cdb665df3a017811eae972840c54dbc74936aad",
+    ("core", "arm64"): "42afe5e00e136c8f8513a2c321a29566811a0c8805aeca4302252604f00e3433",
+    ("imapd", "amd64"): "d13c486e7e19c68f316bae4836d9e94db54892a6eb56260d0d2914aa4babe1b6",
+    ("imapd", "arm64"): "537840c4a3d7cdd529ce611481dd38c7ee41246fb8a678d9abeb4fd843f0f88d",
+    ("lmtpd", "amd64"): "2dd43f8860ee2152b0dffe5e29104add8d6134d9bccf10a21ab1b369b8aa0490",
+    ("lmtpd", "arm64"): "ed26f31fe52eb8cb2104aa877c919443670a0ae42aa832eccc3f70bc497291ba",
 }
 
 
@@ -119,7 +119,7 @@ def _download_dovecot_package(package: str, arch: str) -> tuple[str | None, bool
 
     url_version = DOVECOT_ARCHIVE_VERSION.replace("+", "%2B")
     deb_base = f"{pkg_name}_{url_version}_{arch}.deb"
-    primary_url = f"https://download.delta.chat/dovecot/{deb_base}"
+    primary_url = f"https://download.delta.chat/dovecot/staging-matrix-trixie-trixie/{deb_base}"
     fallback_url = f"https://github.com/chatmail/dovecot/releases/download/upstream%2F{url_version}/{deb_base}"
     url = _pick_url(primary_url, fallback_url)
     deb_filename = f"/root/{deb_base}"


### PR DESCRIPTION
using dovecot build from https://github.com/chatmail/dovecot/pull/8

still needs cmlxc to use debian 13, then we can sort out the errors.