### PR TITLE
fix: crypt-r dependency was declared for wrong Python version

### DIFF
--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "iniconfig",
   "filelock",
   "requests",
-  "crypt-r >= 3.13.1 ; python_version >= '3.11'",
+  "crypt-r >= 3.13.1 ; python_version >= '3.13'",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
The original crypt library was last supported in Python 3.12, so it's not needed until Python 3.13 is default (Trixie)

> The crypt_r module is a renamed copy of the crypt module as it was present in Python 3.12 before it was removed.