### PR TITLE
Revert "Aggressive LMTP header cleanup"

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
+++ b/cmdeploy/src/cmdeploy/postfix/lmtp_header_cleanup
@@ -1,23 +1,3 @@
-# List of headers for incoming messages 
-# that must be retained for functionality and compatibility reasons 
-/^From:/            DUNNO
-/^Message-Id:/      DUNNO
-/^Chat-/            DUNNO
-/^Content-Type:/    DUNNO
-
-# For receiving clear-text messages (still supported in May 2026)
-/^Subject:/         DUNNO
-/^Date:/            DUNNO
-/^To:/              DUNNO
-/^CC:/              DUNNO
-/^References:/      DUNNO
-/^In-Reply-To:/     DUNNO
-
-# Senders might support Autocrypt 1 but not RFC9788 (Header Protection) 
-/^Autocrypt:/       DUNNO
-
-# SecureJoin V2 protocol headers (for backward compatibility) 
-/^Secure-Join/      DUNNO
-
-# Ignore all other headers
-/.*/                IGNORE
+/^DKIM-Signature:/            IGNORE
+/^Authentication-Results:/            IGNORE
+/^Received:/            IGNORE


### PR DESCRIPTION
Reverts chatmail/relay#816

I think this needs to be temporarily reverted as I've noticed on my servers where I updated filtermail and have not set `FILTERMAIL_SKIP_DKIM=true`, there are a *lot* of DKIM validation failures happening. I suspect we're stripping headers before filtermail can validate the DKIM.