### PR TITLE
feat(mtail): add incoming_mailer_daemon_mail_count

### DIFF
--- a/cmdeploy/src/cmdeploy/mtail/delivered_mail.mtail
+++ b/cmdeploy/src/cmdeploy/mtail/delivered_mail.mtail
@@ -73,6 +73,11 @@ counter incoming_unencrypted_mail_count
   filtered_incoming_mail_count++
 }
 
+counter incoming_mailer_daemon_mail_count
+/Incoming: Filtering mailer-daemon message from/ {
+  incoming_mailer_daemon_mail_count++
+  filtered_incoming_mail_count++
+}
 
 counter rejected_unencrypted_mail_count
 /Rejected unencrypted mail/ {


### PR DESCRIPTION
Track volume of mailer-daemon messages separately from unencrypted, to allow plots like this:
<img width="1035" height="515" alt="image" src="https://github.com/user-attachments/assets/6679e5ec-f0a2-405a-9c8a-931fe8f03d45" />
