### PR TITLE
chore: update Let's Encrypt Subscriber Agreement to 1.8

### DIFF
--- a/cmdeploy/src/cmdeploy/acmetool/response-file.yaml.j2
+++ b/cmdeploy/src/cmdeploy/acmetool/response-file.yaml.j2
@@ -1,2 +1,2 @@
 "acme-enter-email": "{{ email }}"
-"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.7-June-04-2026.pdf": true
+"acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.8-July-06-2026.pdf": true


### PR DESCRIPTION
[INFO] acme.interactor: interaction auto-responder couldn't give a canned response: unknown unique ID, cannot respond: "acme-agreement:https://letsencrypt.org/documents/LE-SA-v1.8-July-06-2026.pdf"