### PR TITLE
refactor(postfix): remove unused "filter" lmtp service

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -76,7 +76,6 @@ lmtp      unix  -       -       y       -       -       lmtp
 anvil     unix  -       -       y       -       1       anvil
 scache    unix  -       -       y       -       1       scache
 postlog   unix-dgram n  -       n       -       1       postlogd
-filter    unix -        n       n       -       -       lmtp
 # Local SMTP server for reinjecting outgoing filtered mail.
 127.0.0.1:{{ config.postfix_reinject_port }} inet  n       -       n       -       100      smtpd
   -o syslog_name=postfix/reinject


### PR DESCRIPTION
It looks like the reason it exists in the default configuration is an example for <https://www.postfix.org/FILTER_README.html> Using this filter requires configuration such as
"-o content_filter=filter:dummy" and we don't have it.