### PR TITLE
feat(dovecot): advertise privacy_mail as admin contact, drop server comment

### DIFF
--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -40,8 +40,12 @@ service imap {
   process_limit = 50000
 }
 
-mail_server_admin = mailto:root@{{ config.mail_domain }}
-mail_server_comment = Chatmail server
+{% if config.privacy_mail %}
+# Advertised to clients as IMAP METADATA /shared/admin (RFC 5464).
+# The privacy_mail contact from chatmail.ini is used because it is
+# the only address set by an operator.
+mail_server_admin = mailto:{{ config.privacy_mail }}
+{% endif %}
 
 # `zlib` enables compressing messages stored in the maildir.
 # See


### PR DESCRIPTION
Came across this small cleanup while sorting the overall privacy policy situation. 

- The hardcoded root@relaydomain address was unusued and no one knew about it and it was used nowhere. Better to use privacy_mail which operators can set which might eventually be shown in the UI's relay list.

- remove generic useless mail_server_comment string. 

Clients receive these values as IMAP METADATA /shared/admin and /shared/comment only for internal debugging/info purposes.