### PR TITLE
fix(cmdeploy): remove redundant unbound-anchor call

### DIFF
--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -166,12 +166,6 @@ class UnboundDeployer(Deployer):
             dest="/etc/resolv.conf",
             force=True,
         )
-        server.shell(
-            name="Generate root keys for validating DNSSEC",
-            commands=[
-                "unbound-anchor -a /var/lib/unbound/root.key || true",
-            ],
-        )
         self.ensure_directory(
             path="/etc/unbound/unbound.conf.d",
         )

--- a/cmdeploy/src/cmdeploy/tests/test_unbound_deployer.py
+++ b/cmdeploy/src/cmdeploy/tests/test_unbound_deployer.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+from cmdeploy import deployers
+
+
+def test_configure_relies_on_service_for_root_trust_anchor(monkeypatch):
+    shell_calls = []
+    monkeypatch.setattr(deployers.apt, "packages", lambda **kwargs: None)
+    monkeypatch.setattr(
+        deployers.server,
+        "shell",
+        lambda **kwargs: shell_calls.append(kwargs),
+    )
+
+    deployer = deployers.UnboundDeployer(SimpleNamespace(disable_ipv6=False))
+    monkeypatch.setattr(deployer, "put_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(deployer, "ensure_directory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(deployer, "put_template", lambda *args, **kwargs: None)
+
+    deployer.configure()
+
+    commands = [command for call in shell_calls for command in call["commands"]]
+    assert not any("unbound-anchor" in command for command in commands)


### PR DESCRIPTION
Fixes #542

Removes the manual `unbound-anchor` invocation from `UnboundDeployer.configure()`. Debian's `unbound.service` already updates the root trust anchor before startup.

Adds a regression test ensuring configuration does not schedule another `unbound-anchor` command.