### PR TITLE
feat: setup websockify

### DIFF
--- a/cmdeploy/src/cmdeploy/deployers.py
+++ b/cmdeploy/src/cmdeploy/deployers.py
@@ -32,6 +32,7 @@ from .external.deployer import ExternalTlsDeployer
 from .filtermail.deployer import FiltermailDeployer
 from .mtail.deployer import MtailDeployer
 from .nginx.deployer import NginxDeployer
+from .websockify.deployer import WebsockifyDeployer
 from .opendkim.deployer import OpendkimDeployer
 from .postfix.deployer import PostfixDeployer
 from .selfsigned.deployer import SelfSignedTlsDeployer
@@ -565,6 +566,7 @@ def deploy_chatmail(config_path: Path, disable_mail: bool, website_only: bool) -
         PostfixDeployer(config, disable_mail),
         FcgiwrapDeployer(),
         NginxDeployer(config),
+        WebsockifyDeployer(config),
         MtailDeployer(config.mtail_address),
         GithashDeployer(),
     ]

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -140,6 +140,20 @@ http {
                         proxy_pass http://127.0.0.1:3340;
                         proxy_http_version 1.1;
 		}
+
+		location /imap {
+			proxy_pass http://127.0.0.1:8143;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+		}
+
+		location /smtp {
+			proxy_pass http://127.0.0.1:8587;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "upgrade";
+		}
 	}
 
 	# Redirect www. to non-www

--- a/cmdeploy/src/cmdeploy/websockify/deployer.py
+++ b/cmdeploy/src/cmdeploy/websockify/deployer.py
@@ -1,0 +1,19 @@
+from pyinfra.operations import apt, server
+
+from cmdeploy.basedeploy import Deployer
+
+
+class WebsockifyDeployer(Deployer):
+    def __init__(self, config):
+        self.config = config
+
+    def install(self):
+        apt.packages(name="Install websockify", packages=["websockify"])
+
+    def configure(self):
+        self.ensure_systemd_unit("websockify/websockify-imap.service")
+        self.ensure_systemd_unit("websockify/websockify-submission.service")
+
+    def activate(self):
+        self.ensure_service("websockify-imap.service")
+        self.ensure_service("websockify-submission.service")

--- a/cmdeploy/src/cmdeploy/websockify/websockify-imap.service
+++ b/cmdeploy/src/cmdeploy/websockify/websockify-imap.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=WebSocket proxy for IMAP
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/websockify 127.0.0.1:8143 localhost:143
+DynamicUser=true
+
+[Install]
+WantedBy=multi-user.target

--- a/cmdeploy/src/cmdeploy/websockify/websockify-submission.service
+++ b/cmdeploy/src/cmdeploy/websockify/websockify-submission.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=WebSocket proxy for SMTP
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/websockify 127.0.0.1:8587 localhost:587
+DynamicUser=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change makes it possible
to connect the client over WebSocket.
Running `websocat wss://example.org/imap`
connects to the IMAP
and running `websocat wss://example.org/smtp`
connects to SMTP (submission service, not port 25).

Connecting from a web client will still need a CORS policy for clients not running on the same domain,
but for non-web clients this is already usable.