### PR TITLE
cleanup: contents:read not needed for relay repo

### DIFF
--- a/.github/workflows/ci-no-dns.yaml
+++ b/.github/workflows/ci-no-dns.yaml
@@ -20,8 +20,6 @@ concurrency:
 jobs:
   no-dns:
     name: LXC deploy and test
-    permissions:
-      contents: read
     uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@main
     with:
       cmlxc_version: main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,8 +57,6 @@ jobs:
 
   lxc-test:
     name: LXC deploy and test
-    permissions:
-      contents: read
     uses: chatmail/cmlxc/.github/workflows/lxc-test.yml@main
     with:
       cmlxc_version: main


### PR DESCRIPTION
public repos need no contents::read and there were permissions: {}