### PR TITLE
chore(release): prepare for 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking Changes
 
 - [**breaking**] Introduce configurable system limits to reject new address creation and limit imap/smtp connections.
+  Dovecot default connection limit lowered from 50k to 10k,
+  Postfix default connection limit lowered from 5k to 1k,
+  larger relays need to adjust their settings.
 
 ### Features
 
@@ -23,7 +26,7 @@
 - Always deploy unbound.conf.d/chatmail.conf (#993)
 - Expire empty directories (#994)
 - Crypt-r dependency was declared for wrong Python version
-- Still overwrite /etc/resolv.conf if it is a symbolic link
+- Always overwrite /etc/resolv.conf, even if it is a symbolic link
 - Pass kwargs to files.put()
 - List Iroh proxy endpoints used by 0.35 and 1.0, drop stale /relay/probe from earlier versions
 - Fix port discovery when ss -tulpn shows dovecot before stats
@@ -37,11 +40,10 @@
 
 ### Miscellaneous Tasks
 
-- Auto-trigger docker build on release tag push
-- *(acmetool)* Update let's encrypt ToS link
-- Update Let's Encrypt Subscriber Agreement to 1.8
+- *(ci)* Auto-trigger docker build on release tag push
+- *(acmetool)* Update let's encrypt ToS link to 1.8
 - *(ci)* Update doc staging upload path
-- Fix docs upload path
+- *(ci)* Fix docs upload path
 
 ### Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog for chatmail deployment
 
+## [1.12.0] - 2026-07-31
+
+### Breaking Changes
+
+- [**breaking**] Introduce configurable system limits to reject new address creation and limit imap/smtp connections.
+
+### Features
+
+- Reduce maximal_queue_lifetime from 5d to 2d
+- Disable negative cache in unbound (#992)
+- *(mtail)* Add incoming_mailer_daemon_mail_count
+- *(postfix)* Disable processing of MIME headers
+- *(dovecot)* Advertise privacy_mail as admin contact, drop server comment
+
+### Bug Fixes
+
+- Set relay restrictions per smtpd service with default reject
+- Reduce maxproc for filtermail-transport LMTP client to 500
+- Core 2.50.0 does not have delete_server_after config anymore.
+- Check if all required ports are available for filtermail (#983)
+- Always deploy unbound.conf.d/chatmail.conf (#993)
+- Expire empty directories (#994)
+- Crypt-r dependency was declared for wrong Python version
+- Still overwrite /etc/resolv.conf if it is a symbolic link
+- Pass kwargs to files.put()
+- List Iroh proxy endpoints used by 0.35 and 1.0, drop stale /relay/probe from earlier versions
+- Fix port discovery when ss -tulpn shows dovecot before stats
+
+### Documentation
+
+- Add scripts/initenv.sh to upgrade instructions
+- Update overview diagrams (#995)
+- *(overview)* Remove mermaid styles from 'Accepting and delivering mail' (#1009)
+- *(README.md)* Clarify security enforcement (#1011)
+
+### Miscellaneous Tasks
+
+- Auto-trigger docker build on release tag push
+- *(acmetool)* Update let's encrypt ToS link
+- Update Let's Encrypt Subscriber Agreement to 1.8
+- *(ci)* Update doc staging upload path
+- Fix docs upload path
+
+### Refactor
+
+- *(postfix)* Remove unused "filter" lmtp service
+- Install dns-root-data instead of using unbound-anchor
+- *(deps)* Remove domain-validator dependency
+
+### Testing
+
+- Set socket security for IMAP and SMTP to "TLS" in "dclogin"
+
 ## [1.11.0] - 2026-05-15
 
 ### Breaking Changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,13 @@
 # Releasing a new version of chatmail relay
 
-For example, to release version 1.9.0 of chatmail relay, do the following steps.
+For example, to release version 1.13.0 of chatmail relay, do the following steps.
 
-1. Update the changelog: `git cliff --unreleased --tag 1.9.0 --prepend CHANGELOG.md` or `git cliff -u -t 1.9.0 -p CHANGELOG.md`.
+1. Update the changelog: `git cliff --unreleased --tag 1.13.0 --prepend CHANGELOG.md` or `git cliff -u -t 1.13.0 -p CHANGELOG.md`.
 
 2. Open the changelog in the editor, edit it if required.
 
 3. Commit the changes to the changelog with a commit message `chore(release): prepare for 1.9.0`.
 
-3. Tag the release: `git tag --annotate 1.9.0`.
+4. Open a PR with the new commit, merge it to main after review.
 
-4. Push the release tag: `git push origin 1.9.0`.
-
-5. Create a GitHub release: `gh release create 1.9.0`.
+5. In the web interface, create a GitHub release, tell it to create a new tag.


### PR DESCRIPTION
The last tag was not on main: https://github.com/chatmail/relay/tree/1.11.0

Let's avoid this in the future by just creating the tag with the github release in the web interface after merging the changelog PR.

(squash merge)