### PR TITLE
fix(dns): find authoritative server for CNAME hosts

### DIFF
--- a/cmdeploy/src/cmdeploy/remote/rdns.py
+++ b/cmdeploy/src/cmdeploy/remote/rdns.py
@@ -65,16 +65,22 @@ def get_dkim_entry(mail_domain, pre_command, dkim_selector):
 
 
 def get_authoritative_ns(domain):
-    ns_replies = [
-        x.split()
-        for x in shell(
-            f"dig -r -q {domain} -t NS +noall +authority +answer", print=log_progress
-        ).split("\n")
-    ]
-    filtered_replies = [a for a in ns_replies if len(a) >= 5 and a[3] == "NS"]
-    if not filtered_replies:
-        return
-    return filtered_replies[0][4]
+    """Find the closest authoritative nameserver for a domain."""
+    labels = domain.rstrip(".").split(".")
+    for index in range(len(labels)):
+        candidate = ".".join(labels[index:])
+        ns_replies = [
+            x.split()
+            for x in shell(
+                f"dig -r -q {candidate} -t NS +noall +authority +answer",
+                print=log_progress,
+            ).split("\n")
+        ]
+        filtered_replies = [
+            reply for reply in ns_replies if len(reply) >= 5 and reply[3] == "NS"
+        ]
+        if filtered_replies:
+            return filtered_replies[0][4]
 
 
 def query_dns(typ, domain):

--- a/cmdeploy/src/cmdeploy/tests/test_dns.py
+++ b/cmdeploy/src/cmdeploy/tests/test_dns.py
@@ -141,6 +141,28 @@ def test_get_authoritative_ns(domain, ns, mockdns):
     assert get_authoritative_ns(domain) == ns
 
 
+def test_get_authoritative_ns_walks_to_zone(monkeypatch):
+    replies = {
+        "www.some.domain": (
+            "some.domain. 1800 IN SOA ns1.some.domain. hostmaster.some.domain. "
+            "1 10000 2400 604800 1800\n"
+            "www.some.domain. 1800 IN NSEC \\000.www.some.domain. A AAAA"
+        ),
+        "some.domain": "some.domain. 3600 IN NS ns1.some.domain.",
+    }
+    queried_domains = []
+
+    def shell(command, print):
+        chunks = command.split()
+        queried_domains.append(chunks[3])
+        return replies[chunks[3]]
+
+    monkeypatch.setattr(remote.rdns, "shell", shell)
+
+    assert get_authoritative_ns("www.some.domain") == "ns1.some.domain."
+    assert queried_domains == ["www.some.domain", "some.domain"]
+
+
 def test_parse_zone_records():
     text = """
     ; This is a comment


### PR DESCRIPTION
## Summary

- walk toward the DNS zone apex when an NS query for the exact hostname returns no NS record
- keep querying the discovered authoritative server directly instead of falling back to a recursive resolver
- cover SOA/NSEC responses at CNAME hostnames with a regression test

## Root cause

`get_authoritative_ns()` only inspected the NS response for the exact record name. Some authoritative DNS setups return an SOA plus a signed NSEC denial for an NS query at a CNAME hostname. The function then returned no server, so `query_dns()` silently used the deployment host's recursive resolver.

A validating resolver can reuse that NSEC denial for the immediately following CNAME query, causing `cmdeploy` to report a correct CNAME as missing. Retrying recreates the same sequence.

Walking the labels toward the zone apex finds the public authoritative NS and restores the intended cache-bypassing lookup.

## Validation

- `pytest cmdeploy/src/cmdeploy/tests/test_dns.py -q` (24 passed)
- `pytest cmdeploy/src/cmdeploy/tests --ignore=cmdeploy/src/cmdeploy/tests/online -q` (49 passed)
- `ruff check cmdeploy/src/cmdeploy/remote/rdns.py cmdeploy/src/cmdeploy/tests/test_dns.py`
- `ruff format --check cmdeploy/src/cmdeploy/remote/rdns.py cmdeploy/src/cmdeploy/tests/test_dns.py`
- live `scripts/cmdeploy dns -v` validation against the affected relay completed with all DNS entries verified
