### PR TITLE
docs: describe Madmail v2 as a Rust chatmail relay

### DIFF
--- a/doc/source/related.rst
+++ b/doc/source/related.rst
@@ -14,10 +14,11 @@ We know of three work-in-progress alternative implementation efforts:
    it to support all of the features and configuration settings required
    to operate as a chatmail relay.
 
--  `Madmail <https://github.com/themadorg/madmail>`_: an
-   experimental fork of `Maddy Mail Server <https://maddy.email/>`_, modified
-   for chatmail deployments.  It provides a single binary solution
-   for running a chatmail relay.
+-  `Madmail <https://github.com/themadorg/madmail>`_: a Rust-based
+   single-binary chatmail relay.  Madmail v2 is a rewrite of an earlier
+   experimental fork of `Maddy Mail Server <https://maddy.email/>`_.
+   It includes SMTP, IMAP, encryption enforcement, and real-time
+   services (TURN/Iroh), and runs on Linux and Windows.
 
 -  `Chatmail Cookbook <https://github.com/feld/chatmail-cookbook>`_:
    A Chef Cookbook implementing a relay server. The project follows the


### PR DESCRIPTION
The community-developments page still described Madmail as an experimental Maddy fork. That applied to v1. Madmail v2 is a Rust rewrite.

This updates only the Madmail bullet so it matches the current project:

- Rust-based single-binary chatmail relay
- SMTP, IMAP, encryption enforcement, and real-time services (TURN/Iroh)
- Linux and Windows
- short note that v2 rewrites the earlier Maddy-based fork

Mox and Chatmail Cookbook entries are unchanged, as is the list intro.

One thing I left as-is: the list intro still says “three work-in-progress alternative implementation efforts.”

That no longer quite fits all three:

- Madmail v2 is a separate Rust implementation, not a WIP Maddy fork.
- The Chatmail Cookbook follows this repo’s software and config; it is a Chef deployment, not an alternative implementation.
- Mox is still the one that is clearly work-in-progress toward chatmail support.

Would you rather reword that sentence, for example to “We know of these community efforts:”, or keep it?