### PR TITLE
ci: try to fix lack of RFC822 item support in madmail and make CI pass

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/plugin.py
+++ b/cmdeploy/src/cmdeploy/tests/plugin.py
@@ -211,7 +211,7 @@ class ImapConn:
         status, res = self.conn.select()
         if int(res[0]) == 0:
             raise ValueError("no messages in imap folder")
-        status, results = self.conn.fetch("1:*", "(RFC822)")
+        status, results = self.conn.fetch("1:*", "(BODY.PEEK[])")
         assert status == "OK"
         return results
 


### PR DESCRIPTION
some local debugging revealed madmail v2 does not support fetching RFC822 items (gives an empty body) so try BODY.PEEK[] instead.