### PR TITLE
fix: actually use UTC time instead of just seemingly using it

### DIFF
--- a/chatmaild/src/chatmaild/expire.py
+++ b/chatmaild/src/chatmaild/expire.py
@@ -259,7 +259,7 @@ def daily_expire_main(args=None):
     args = parser.parse_args(args)
 
     config = read_config(args.chatmail_ini)
-    now = datetime.utcnow().timestamp()
+    now = time.time()
     if args.days:
         now = now - 86400 * int(args.days)
 

--- a/chatmaild/src/chatmaild/fsreport.py
+++ b/chatmaild/src/chatmaild/fsreport.py
@@ -27,6 +27,7 @@ to also write legacy metrics.py style output (default: /var/www/html/metrics):
 
 import os
 import tempfile
+import time
 from argparse import ArgumentParser
 from datetime import datetime
 
@@ -264,7 +265,7 @@ def main(args=None):
 
     config = read_config(args.chatmail_ini)
 
-    now = datetime.utcnow().timestamp()
+    now = time.time()
     if args.days:
         now = now - 86400 * int(args.days)
 

--- a/chatmaild/src/chatmaild/tests/test_expire.py
+++ b/chatmaild/src/chatmaild/tests/test_expire.py
@@ -3,7 +3,6 @@ import os
 import random
 import shutil
 import time
-from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -41,7 +40,7 @@ def fill_mbox(folderdir):
 
 
 def create_new_messages(basedir, relpaths, size=1000, days=0):
-    now = datetime.utcnow().timestamp()
+    now = time.time()
 
     for relpath in relpaths:
         msg_path = Path(basedir).joinpath(relpath)
@@ -112,9 +111,7 @@ def test_mbox_without_password(mbox1, example_config, capsys):
     mbox_rescan = MailboxStat(mbox1.basedir)
     assert mbox_rescan.last_login is None
 
-    exp = Expiry(
-        example_config, dry=False, now=datetime.now().timestamp(), verbose=False
-    )
+    exp = Expiry(example_config, dry=False, now=time.time(), verbose=False)
     exp.process_mailbox_stat(mbox_rescan)
     out, err = capsys.readouterr()
     assert "doesn't have last_login but isn't empty" in err
@@ -152,7 +149,7 @@ def test_report_mdir_filters_by_path(mbox1, example_config):
     """Test that Report with mdir='cur' only counts messages in cur/ subdirectory."""
     from chatmaild.fsreport import Report
 
-    now = datetime.utcnow().timestamp()
+    now = time.time()
 
     # Set password mtime to old enough so min_login_age check passes
     password = Path(mbox1.basedir).joinpath("password")


### PR DESCRIPTION
`datetime.utcnow().timestamp()` is actually 7200 seconds in the past. The Python deprecation warning of `utcnow()` warning actually pointed there, and is also fixed. 
```
>>> datetime.utcnow().timestamp() - time.time()
-7200.000010251999
```

i really wonder if no one else minds seeing such garbage after each test run :) 

<img width="1890" height="728" alt="image" src="https://github.com/user-attachments/assets/22dbfe85-99c8-4ed9-9357-42dd23f7ebdf" />
